### PR TITLE
pwa.md typo and other small improvements

### DIFF
--- a/content/en/features/pwa.md
+++ b/content/en/features/pwa.md
@@ -6,13 +6,13 @@ position: 17
 category: Features
 features:
   - 💹 Better performance
-  - 📱 Mobile optimized UI
+  - 📱 Mobile-optimized UI
   - 🕙 Automatically Updates
-  - 💻📱 Cross-Paltform
+  - 💻📱 Cross-Platform
 
 ---
 
-Hoppscotch is also available as PWA Progressive Web App.
+Hoppscotch is also available as a PWA (Progressive Web App).
 
 Benefits:
 <list :items="features"></list>
@@ -22,6 +22,6 @@ Benefits:
 1. On your computer, open Chrome.
 2. Go to [hoppscotch.io](https://hoppscotch.io/).
 3. At the top right of the address bar, click Install ➕.
-4. Follow the onscreen instructions to install the PWA.
+4. Follow the on-screen instructions to install the PWA.
 
 


### PR DESCRIPTION
Fixed a typo (`paltform` -> `platform`) and made a couple other small grammatical improvements.

Thanks for this great app!