### PR TITLE
fix: fixed incorrect container used in enterprise section

### DIFF
--- a/content/1.documentation/5.self-host/2.enterprise-edition/2.install-and-build.md
+++ b/content/1.documentation/5.self-host/2.enterprise-edition/2.install-and-build.md
@@ -173,7 +173,7 @@ docker pull hoppscotch/hoppscotch-enterprise
 After pulling the container, start Hoppscotch by running the container:
 
 ```bash
-docker run -p 3000:3000 -p 3100:3100 -p 3170:3170 --env-file .env hoppscotch/hoppscotch
+docker run -p 3000:3000 -p 3100:3100 -p 3170:3170 --env-file .env hoppscotch/hoppscotch-enterprise
 ```
 
 ::alert{type="info"}


### PR DESCRIPTION
In this PR I am introducing a fix in the `Install and Build` section on the Enterprise docs.