### PR TITLE
docs(realtime): fix typo

### DIFF
--- a/content/1.documentation/1.getting-started/6.realtime/3.mqtt.md
+++ b/content/1.documentation/1.getting-started/6.realtime/3.mqtt.md
@@ -30,7 +30,7 @@ alt: Hoppscotch MQTT
 
 Write your message in the **Message** input field under the **Communication** tab and click on the **Publish** button. Type in the **Topic** input field to send a message with a topic. The message you send will be displayed on the **Logs** pane.
 
-## Subscribtions
+## Subscriptions
 
 Click on the "New Subscription" button to add a new subscription. Enter the topic name and click on the "Subscribe" button to subscribe to the topic. The messages you receive will be displayed on the **Logs** pane.
 


### PR DESCRIPTION
Fix a typo on the `MQTT` page.