### PR TITLE
docs: adjust callback url according to the callback url pattern

### DIFF
--- a/content/1.documentation/5.self-host/1.community-edition/1.prerequisites.md
+++ b/content/1.documentation/5.self-host/1.community-edition/1.prerequisites.md
@@ -142,7 +142,7 @@ For example, if you are using GitHub as your OAuth provider, you will need to ge
 ```yaml
 GITHUB_CLIENT_ID="*****"
 GITHUB_CLIENT_SECRET="*****"
-GITHUB_CALLBACK_URL="http://localhost:3170/auth/github/callback"
+GITHUB_CALLBACK_URL="http://localhost:3170/v1/auth/github/callback"
 GITHUB_SCOPE="user:email"
 ```
 

--- a/content/1.documentation/5.self-host/2.enterprise-edition/1.prerequisites.md
+++ b/content/1.documentation/5.self-host/2.enterprise-edition/1.prerequisites.md
@@ -182,7 +182,7 @@ For example, if you are using GitHub as your OAuth provider, you will need to ge
 ```yaml
 GITHUB_CLIENT_ID="*****"
 GITHUB_CLIENT_SECRET="*****"
-GITHUB_CALLBACK_URL="http://localhost:3170/auth/github/callback"
+GITHUB_CALLBACK_URL="http://localhost:3170/v1/auth/github/callback"
 GITHUB_SCOPE="user:email"
 ```
 


### PR DESCRIPTION
Adjust the auth provider callback urls according to the callback url pattern with `/v1/`. It was missing for the Github callback urls.

Pattern:
`http://localhost:3170/v1/auth/[auth_provider_name]/callback`