### PR TITLE
docs: replace deprecated pnpx with pnpm dlx

### DIFF
--- a/content/1.documentation/5.self-host/1.community-edition/2.install-and-build.md
+++ b/content/1.documentation/5.self-host/1.community-edition/2.install-and-build.md
@@ -214,5 +214,5 @@ docker exec -it <container_id> /bin/sh
 Once inside the container, run the migration using:
 
 ```bash
-pnpx prisma migrate deploy
+pnpm dlx prisma migrate deploy
 ```

--- a/content/1.documentation/5.self-host/2.enterprise-edition/2.install-and-build.md
+++ b/content/1.documentation/5.self-host/2.enterprise-edition/2.install-and-build.md
@@ -217,7 +217,7 @@ docker exec -it <container_id> /bin/sh
 Once inside the container, run the migration using:
 
 ```bash
-pnpx prisma migrate deploy
+pnpm dlx prisma migrate deploy
 ```
 
 ## ClickHouse setup


### PR DESCRIPTION
pnpx was announced to be deprecated with [pnpm 6](https://github.com/pnpm/pnpm.io/blob/ab1ffa32235f3e867730e9f5948983a90660b9a9/versioned_docs/version-6.x/pnpx-cli.md)

Unfortunately you will not anymore find this deprecation notice in the docs, because the [pnpx-cli page was removed completely from the docs](https://github.com/pnpm/pnpm.io/commit/e90a748139b800bb0685ec3a9183ac000b9826cc).