### PR TITLE
Document how to configure GitHub Enterprise as OAuth2 identity provider

### DIFF
--- a/content/1.documentation/5.self-host/1.community-edition/1.prerequisites.md
+++ b/content/1.documentation/5.self-host/1.community-edition/1.prerequisites.md
@@ -150,6 +150,27 @@ The `CALLBACK_URL` variable is the URL that is invoked after the authorization i
 
 The `SCOPE` variable defines the scope of the data that the OAuth provider passes on to Hoppscotch.
 
+By default, public GitHub is used as the OAuth provider. However, an instance of Github Enterprise can also be used as the provider. To configure that, the following environment variables must be set:
+- `GITHUB_AUTHORIZATION_URL`: Authorization endpoint.
+- `GITHUB_TOKEN_URL`: Endpoint to retrieve access token.
+- `GITHUB_USER_PROFILE_URL`: Endpoint to retrieve general user info (e.g., full name).
+- `GITHUB_USER_EMAIL_URL`: Endpoint to retrieve user emails.
+
+Sample configuration:
+```yaml
+# New configuration settings================================================
+GITHUB_AUTHORIZATION_URL=https://{{ENTERPRISE_INSTANCE_HOST_NAME}}/login/oauth/authorize
+GITHUB_TOKEN_URL=https://{{ENTERPRISE_INSTANCE_HOST_NAME}}/login/oauth/access_token
+GITHUB_USER_PROFILE_URL=https:/{{ENTERPRISE_INSTANCE_HOST_NAME}}/api/v3/user
+GITHUB_USER_EMAIL_URL=https://{{ENTERPRISE_INSTANCE_HOST_NAME}}/api/v3/user/emails
+
+# Configuration settings that remain unchanged in meaning============================= 
+GITHUB_CLIENT_ID=*****************************************
+GITHUB_CLIENT_SECRET=*****************************************
+GITHUB_CALLBACK_URL=http://localhost:3170/v1/auth/github/callback
+GITHUB_SCOPE="user:email"
+```
+
 The links to configure OAuth for various providers are given below:
 
 1. [**GitHub**](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/creating-an-oauth-app) (scope: email)

--- a/content/1.documentation/5.self-host/2.enterprise-edition/1.prerequisites.md
+++ b/content/1.documentation/5.self-host/2.enterprise-edition/1.prerequisites.md
@@ -190,6 +190,27 @@ The `CALLBACK_URL` variable is the URL that is invoked after the authorization i
 
 The `SCOPE` variable defines the scope of the data that the OAuth provider passes on to Hoppscotch.
 
+By default, public GitHub is used as the OAuth provider. However, an instance of Github Enterprise can also be used as the provider. To configure that, the following environment variables must be set:
+- `GITHUB_AUTHORIZATION_URL`: Authorization endpoint.
+- `GITHUB_TOKEN_URL`: Endpoint to retrieve access token.
+- `GITHUB_USER_PROFILE_URL`: Endpoint to retrieve general user info (e.g., full name).
+- `GITHUB_USER_EMAIL_URL`: Endpoint to retrieve user emails.
+
+Sample configuration:
+```yaml
+# New configuration settings================================================
+GITHUB_AUTHORIZATION_URL=https://{{ENTERPRISE_INSTANCE_HOST_NAME}}/login/oauth/authorize
+GITHUB_TOKEN_URL=https://{{ENTERPRISE_INSTANCE_HOST_NAME}}/login/oauth/access_token
+GITHUB_USER_PROFILE_URL=https:/{{ENTERPRISE_INSTANCE_HOST_NAME}}/api/v3/user
+GITHUB_USER_EMAIL_URL=https://{{ENTERPRISE_INSTANCE_HOST_NAME}}/api/v3/user/emails
+
+# Configuration settings that remain unchanged in meaning============================= 
+GITHUB_CLIENT_ID=*****************************************
+GITHUB_CLIENT_SECRET=*****************************************
+GITHUB_CALLBACK_URL=http://localhost:3170/v1/auth/github/callback
+GITHUB_SCOPE="user:email"
+```
+
 The links to configure OAuth for various providers are given below:
 
 1. [**GitHub**](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/creating-an-oauth-app) (scope: email)


### PR DESCRIPTION
This PR adds documentation for how to configure an instance of GitHub enterprise as the OAuth2 identity provider.

The work to enable this feature is done as part of another [PR](https://github.com/hoppscotch/hoppscotch/pull/3568).