### PR TITLE
Update 2.install-and-build.md individual ports

### DIFF
--- a/content/1.documentation/5.self-host/1.community-edition/2.install-and-build.md
+++ b/content/1.documentation/5.self-host/1.community-edition/2.install-and-build.md
@@ -142,9 +142,9 @@ docker pull hoppscotch/hoppscotch-admin
 After pulling the containers, start Hoppscotch by running all three services:
 
 ```bash
-docker run -p 3000:3000 --env-file .env hoppscotch-frontend
+docker run -p 3000:8080 --env-file .env hoppscotch-frontend
 docker run -p 3170:3170 --env-file .env hoppscotch-backend
-docker run -p 3100:3100 --env-file .env hoppscotch-admin
+docker run -p 3100:8080 --env-file .env hoppscotch-admin
 ```
 
 ::alert{type="info"}


### PR DESCRIPTION
The individual docker images use different internal ports than the AIO image. This commit changes the `docker run` port mapping to make this clear.