### PR TITLE
chore: added migration error to migration section

### DIFF
--- a/content/1.documentation/5.self-host/1.community-edition/2.install-and-build.md
+++ b/content/1.documentation/5.self-host/1.community-edition/2.install-and-build.md
@@ -244,7 +244,7 @@ pnpx prisma migrate deploy
 Should the user ever encounter the following error:
 
 ```bash
-Error: Database migration not performed. Please check the FAQ for assistance: https://docs.hoppscotch.io/support/getting-started/faq
+Database migration not found. Please check the documentation for assistance: https://docs.hoppscotch.io/documentation/self-host/community-edition/install-and-build#running-migrations
 ```
 
 It means the user is trying to start the backend (or AIO) service before the database has all the relevant tables in it. In order to run the migration to populate the database run the following command.

--- a/content/1.documentation/5.self-host/1.community-edition/2.install-and-build.md
+++ b/content/1.documentation/5.self-host/1.community-edition/2.install-and-build.md
@@ -201,12 +201,11 @@ When using the individual containers it is up to the users to configure a revers
 
 When using AIO, when subpath access is set to true the services can be accessed from the following routes
 
-| Service    | Route |
-| -------- | ------- |
-| Hoppscotch App  | `/`    |
-| Hoppscotch Admin App | `/admin`    |
-| Hoppscotch Backend    | `/backend`    |
-
+| Service              | Route      |
+| -------------------- | ---------- |
+| Hoppscotch App       | `/`        |
+| Hoppscotch Admin App | `/admin`   |
+| Hoppscotch Backend   | `/backend` |
 
 ## Migrations
 
@@ -240,4 +239,30 @@ Once inside the container, run the migration using:
 
 ```bash
 pnpx prisma migrate deploy
+```
+
+Should the user ever encounter the following error:
+
+```bash
+Error: Database migration not performed. Please check the FAQ for assistance: https://docs.hoppscotch.io/support/getting-started/faq
+```
+
+It means the user is trying to start the backend (or AIO) service before the database has all the relevant tables in it. In order to run the migration to populate the database run the following command.
+
+```bash
+docker run -it --entrypoint sh --env-file .env <container_name>
+```
+
+Making sure to pass in the `.env` file containing the right `.env` variables for the instance. On executing the aforementioned command will result in a shell being opened inside a instance of the container following which user can execute a database migration normally with
+
+```bash
+	pnpx prisma migrate deploy
+```
+
+Once the database has been successfully run and the database populated with tables the backend containers ( or AIO container) can be started normally.
+
+Note: If user is using `docker compose` to run the services the following command can be used to open a shell inside the backend (or AIO) service.
+
+```bash
+docker compose run --entrypoint sh <Service_name>
 ```

--- a/content/1.documentation/5.self-host/2.enterprise-edition/2.install-and-build.md
+++ b/content/1.documentation/5.self-host/2.enterprise-edition/2.install-and-build.md
@@ -154,8 +154,8 @@ docker run -p 3100:3100 --env-file .env --restart unless-stopped hoppscotch-ente
 ::list{type="info"}
 
 - Ensure that the environment variables are configured in the `.env` file and the restart policy is mentioned.
-  ::
-  ::
+::
+::
 
 Open [admin dashboard](http://localhost:3100) or [`PORT 3100`](http://localhost:3100) in the browser to [setup and access](/documentation/self-host/enterprise-edition/setup-and-access) the Hoppscotch instance.
 

--- a/content/1.documentation/5.self-host/2.enterprise-edition/2.install-and-build.md
+++ b/content/1.documentation/5.self-host/2.enterprise-edition/2.install-and-build.md
@@ -246,7 +246,7 @@ pnpx prisma migrate deploy
 Should the user ever encounter the following error:
 
 ```bash
-Error: Database migration not performed. Please check the FAQ for assistance: https://docs.hoppscotch.io/support/getting-started/faq
+Database migration not found. Please check the documentation for assistance: https://docs.hoppscotch.io/documentation/self-host/community-edition/install-and-build#running-migrations
 ```
 
 It means the user is trying to start the backend (or AIO) service before the database has all the relevant tables in it. In order to run the migration to populate the database run the following command.

--- a/content/1.documentation/5.self-host/2.enterprise-edition/2.install-and-build.md
+++ b/content/1.documentation/5.self-host/2.enterprise-edition/2.install-and-build.md
@@ -154,8 +154,8 @@ docker run -p 3100:3100 --env-file .env --restart unless-stopped hoppscotch-ente
 ::list{type="info"}
 
 - Ensure that the environment variables are configured in the `.env` file and the restart policy is mentioned.
-::
-::
+  ::
+  ::
 
 Open [admin dashboard](http://localhost:3100) or [`PORT 3100`](http://localhost:3100) in the browser to [setup and access](/documentation/self-host/enterprise-edition/setup-and-access) the Hoppscotch instance.
 
@@ -241,6 +241,32 @@ Once inside the container, run the migration using:
 
 ```bash
 pnpx prisma migrate deploy
+```
+
+Should the user ever encounter the following error:
+
+```bash
+Error: Database migration not performed. Please check the FAQ for assistance: https://docs.hoppscotch.io/support/getting-started/faq
+```
+
+It means the user is trying to start the backend (or AIO) service before the database has all the relevant tables in it. In order to run the migration to populate the database run the following command.
+
+```bash
+docker run -it --entrypoint sh --env-file .env <container_name>
+```
+
+Making sure to pass in the `.env` file containing the right `.env` variables for the instance. On executing the aforementioned command will result in a shell being opened inside a instance of the container following which user can execute a database migration normally with
+
+```bash
+	pnpx prisma migrate deploy
+```
+
+Once the database has been successfully run and the database populated with tables the backend containers ( or AIO container) can be started normally.
+
+Note: If user is using `docker compose` to run the services the following command can be used to open a shell inside the backend (or AIO) service.
+
+```bash
+docker compose run --entrypoint sh <Service_name>
 ```
 
 ## ClickHouse setup


### PR DESCRIPTION
In this PR we have added details on what users need to do when they encounter a database docker exec -it container_id bash issue.