### PR TITLE
docs(cli): mention the minimum supported Node.js version

### DIFF
--- a/content/1.documentation/2.clients/2.cli.md
+++ b/content/1.documentation/2.clients/2.cli.md
@@ -24,6 +24,8 @@ To download and install Hoppscotch CLI, run the following command in your termin
 npm i -g @hoppscotch/cli
 ```
 
+> The minimum supported Node.js version for the CLI is v18.
+
 ## Commands
 
 ### `hopp test`


### PR DESCRIPTION
The minimum supported Node.js version for the CLI was bumped to `v18` in https://github.com/hoppscotch/hoppscotch/pull/3441. This PR adds a note about the same in the docs.

Closes HP-176.