### PR TITLE
Adding missing subpath env varible in the docs

### DIFF
--- a/documentation/self-host/community-edition/install-and-build.mdx
+++ b/documentation/self-host/community-edition/install-and-build.mdx
@@ -72,6 +72,8 @@ VITE_BACKEND_API_URL=http://localhost:3170/v1
 # Terms Of Service And Privacy Policy Links (Optional)
 VITE_APP_TOS_LINK=https://docs.hoppscotch.io/support/terms
 VITE_APP_PRIVACY_POLICY_LINK=https://docs.hoppscotch.io/support/privacy
+
+ENABLE_SUBPATH_BASED_ACCESS=false
 ```
 
 Let's understand the major environment variables:

--- a/documentation/self-host/enterprise-edition/install-and-build.mdx
+++ b/documentation/self-host/enterprise-edition/install-and-build.mdx
@@ -73,6 +73,8 @@ VITE_BACKEND_API_URL=http://localhost:3170/v1
 VITE_APP_TOS_LINK=https://docs.hoppscotch.io/support/terms
 VITE_APP_PRIVACY_POLICY_LINK=https://docs.hoppscotch.io/support/privacy
 
+ENABLE_SUBPATH_BASED_ACCESS=false
+
 ENTERPRISE_LICENSE_KEY=***************************************
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "docs",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
In this PR we are adding the following missing `ENABLE_SUBPATH_BASED_ACCESS` variable into the self-host documentation pages.