### PR TITLE
v2024.8.0 Documentation Updates: AWS Signature Auth Method, Description field, Import HAR files

### DIFF
--- a/documentation/features/authorization.mdx
+++ b/documentation/features/authorization.mdx
@@ -62,13 +62,19 @@ The client credentials grant type is commonly employed for accessing data tied t
 
 The OAuth 2.0 Password grant type sends the username and password directly from the client, which is not advised when handling third-party data.
 
-To utilize the password grant type, input your API provider's **Access Token URL**, along with the Username and Password. Occasionally, you may also be required to supply a client ID and secret.
+To utilize the password grant type, input your API provider's **Access Token URL**, along with the **Username** and **Password**. Occasionally, you may also be required to supply a client ID and secret.
 
 #### 4. Implicit
 
 The Implicit grant type furnishes the client with an access token directly, eliminating the additional authentication code step and is less secure.
 
-For utilizing the implicit grant type in your requests via Hoppscotch, provide a Callback URL registered with the API provider, the provider's Auth URL, and a Client ID for the registered application.
+For utilizing the implicit grant type in your requests via Hoppscotch, provide a **Callback URL** registered with the API provider, the provider's **Auth URL**, and a **Client ID** for the registered application.
+
+## AWS Signature
+
+The AWS Signature authorization mechanism authenticates and authorizes requests to AWS services by employing HMAC (Hash-based Message Authentication Code). This ensures that your requests are secure, verifiable, and protected against tampering.
+
+To configure AWS Signature authorization in Hoppscotch, enter your AWS **Access Key** and **Secret Key** to sign your requests. For advanced configuration, you can also provide details like the **AWS Region** where your request will be processed, the **Service Name** of the AWS service you're accessing, and a **Service Token** if you're using temporary security credentials.
 
 ---
 

--- a/documentation/features/importer.mdx
+++ b/documentation/features/importer.mdx
@@ -12,6 +12,7 @@ Import data from other tools into Hoppscotch. You can import data from the follo
 | **Postman**        | ✓                                                   | ✓            |
 | **Insomnia**       | ✓                                                   | ✓            |
 | **OpenAPI**        | ✓                                                   |              |
+| **HTTP Archive**   | ✓                                                   |              |
 | **Other services** | [Contact support](/support/getting-started/contact) |              |
 
 ## Import from Hoppscotch
@@ -58,6 +59,13 @@ There are two ways to import OpenAPI collections into Hoppscotch:
 5. Click on the "**Import from URL**" field and paste the URL that you copied in step 1.
 6. Click on the "**Import**" button.
 
+## Import from HAR
+
+1. Export the HTTP Archive (HAR) file from your browser or network monitoring tool.
+2. Open Hoppscotch and click on the "**Import**" button on the collection section.
+3. Click on the "**Import from HAR**" tab.
+4. Click on the "**Choose file**" button and select the HAR file you exported in step 1.
+5. Click on the "**Import**" button.
 
 ## Import from other services
 

--- a/documentation/getting-started/rest/request-headers.mdx
+++ b/documentation/getting-started/rest/request-headers.mdx
@@ -1,0 +1,23 @@
+---
+sidebarTitle: Request headers
+title: Request headers
+description: Request Headers allow you to pass additional information with requests, helping to control how the server responds.
+---
+
+Request Headers are key-value pairs that the client sends to the server with an HTTP request. These headers carry extra details about your request, helping the server understand its context and tailor the response to fit.
+
+## Headers Tab
+
+In Hoppscotch, you can easily set and manage request headers using the **Headers tab**. This tab allows you to define **`key-value`** pairs, and you can also add a **`description`** for each header to keep track of its purpose.
+
+Here are a few common headers you might set:
+
+| **Header**        | **Description**                                                                           |
+| ----------------- | ----------------------------------------------------------------------------------------- |
+| **Authorization** | Used for passing credentials, such as tokens, to authenticate the client with the server. |
+| **Content-Type**  | Indicates the format of the data being sent, like `application/json`.                     |
+| **Accept**        | Tells the server what media types the client can handle in the response.                  |
+| **Cache-Control** | Controls caching behavior in both requests and responses.                                 |
+| **User-Agent**    | Provides information about the client making the request.                                 |
+
+Hoppscotch offers a variety of header options beyond these five examples, allowing you to customize how the server processes your requests to meet specific requirements.

--- a/documentation/getting-started/rest/request-headers.mdx
+++ b/documentation/getting-started/rest/request-headers.mdx
@@ -20,4 +20,17 @@ Here are a few common headers you might set:
 | **Cache-Control** | Controls caching behavior in both requests and responses.                                 |
 | **User-Agent**    | Provides information about the client making the request.                                 |
 
+<Note> For **Authorization and Content-Type** headers, the description field will be disabled, and the value will be empty. In contrast, for **inherited headers**, the specified values will be automatically populated in the description field. </Note>
+
 Hoppscotch offers a variety of header options beyond these five examples, allowing you to customize how the server processes your requests to meet specific requirements.
+
+### Bulk edit request headers
+
+Using the  <Icon icon="pen-to-square" iconType="solid" />  **Bulk edit** feature in Hoppscotch's request headers tab, you can input and manage multiple headers simultaneously, with each header on a new line and the key and value separated by a **colon (:)**. For example,
+
+```yaml
+Authorization: Bearer token123
+Content-Type: application/json
+# User-Agent: CustomAgent/1.0
+```
+

--- a/documentation/getting-started/rest/request-parameters.mdx
+++ b/documentation/getting-started/rest/request-parameters.mdx
@@ -52,4 +52,12 @@ For which you will get a similar response:
 
 You can use the **Parameters tab** to set **`key-value`** pairs for your API requests. This tab also lets you add a **`description`** for each parameter, helping you provide a clear explanation of what each parameter does and why it’s important.
 
+Hoppscotch also offers a <Icon icon="pen-to-square" iconType="solid" />  **Bulk edit** feature, allowing you to add or modify multiple request parameters at once, with each key-value pair on a new line separated by a **colon (:)**. For example,
+
+```yaml
+param1: value1
+param2: value2
+# param3: value3
+```
+
 Try using the parameters tab to see if you get the same response as adding parameters in the URL.

--- a/documentation/getting-started/rest/request-parameters.mdx
+++ b/documentation/getting-started/rest/request-parameters.mdx
@@ -50,6 +50,6 @@ For which you will get a similar response:
 
 ## Using the parameters tab
 
-Additionally, you can add the parameters as a key-value pair in the parameters tab, and these will be appended to the URL automatically when you send the request.
+You can use the **Parameters tab** to set **`key-value`** pairs for your API requests. This tab also lets you add a **`description`** for each parameter, helping you provide a clear explanation of what each parameter does and why it’s important.
 
 Try using the parameters tab to see if you get the same response as adding parameters in the URL.

--- a/mint.json
+++ b/mint.json
@@ -74,6 +74,7 @@
           "pages": [
             "documentation/getting-started/rest/creating-a-request",
             "documentation/getting-started/rest/request-parameters",
+            "documentation/getting-started/rest/request-headers",
             "documentation/getting-started/rest/organizing-requests",
             "documentation/getting-started/rest/environment-variables",
             "documentation/getting-started/rest/auth-tokens",


### PR DESCRIPTION
This PR includes documentation related to the following:

- [x] AWS Signature under [Authorization Page](https://docs.hoppscotch.io/documentation/features/authorization).
- [x] Referenced description field under "[Using Parameters Tab](https://docs.hoppscotch.io/documentation/getting-started/rest/request-parameters#using-the-parameters-tab)" section.
- [x] Created a Request Headers page under "RESTful API" folder and included information about the description field there as well.
- [x] Added section for "Import from HAR" ~~(Waiting for implementation on engineering end to verify the content here)~~.