### PR TITLE
Warning note related to Breaking change in Self-Hosted Edition

### DIFF
--- a/documentation/self-host/community-edition/install-and-build.mdx
+++ b/documentation/self-host/community-edition/install-and-build.mdx
@@ -4,6 +4,8 @@ title: Install and build
 description: Learn how to install and build Hoppscotch Community Edition.
 ---
 
+<Warning> **[v2024.8.0](https://hoppscotch.com/blog/hoppscotch-v2024-8-0)** introduces new additions to the Hoppscotch Backend that require you to run a **new [migration](#migrations)**. We've also added a new environment variable, **`DATA_ENCRYPTION_KEY`**, which accepts a 32 character alphanumeric string. Please make sure to update your `.env` file with the latest changes while setting up Hoppscotch. </Warning>
+
 ## Configuring the environment
 
 Before you get started with the installation, you need to configure the environment variables.

--- a/documentation/self-host/enterprise-edition/install-and-build.mdx
+++ b/documentation/self-host/enterprise-edition/install-and-build.mdx
@@ -4,6 +4,8 @@ title: Install and build
 description: Learn how to install and build Hoppscotch Enterprise Edition.
 ---
 
+<Warning> **[v2024.8.0](https://hoppscotch.com/blog/hoppscotch-v2024-8-0)** introduces new additions to the Hoppscotch Backend that require you to run a **new [migration](#migrations)**. We've also added a new environment variable, **`DATA_ENCRYPTION_KEY`**, which accepts a 32 character alphanumeric string. Please make sure to update your `.env` file with the latest changes while setting up Hoppscotch. </Warning>
+
 ## Configuring the environment
 
 Before you get started with the installation, you need to configure the environment variables.


### PR DESCRIPTION
- [x] Added a warning ⚠️  at the top of the `Install and Build` page for both Self-Hosted Editions, informing users about running new migration due to recent changes in the Hoppscotch backend.