### PR TITLE
Note on limitations of shared workspaces with GraphQL APIs.

### DIFF
--- a/documentation/features/workspaces.mdx
+++ b/documentation/features/workspaces.mdx
@@ -8,7 +8,7 @@ Once you are logged into Hoppscotch, you can toggle between multiple workspaces 
 
 You can choose between your workspace titled "**Personal Workspace**" or create a workspace for your teams so that you can collaborate.
 
-<Note>Currently, organizing requests across multiple shared workspaces is limited to RESTful protocol. GraphQL APIs are available only in personal workspaces and are not supported for collaboration in shared workspaces.</Note>
+<Note>Currently, organizing requests across multiple shared workspaces is limited to RESTful protocol. GraphQL and Realtime APIs are available only in the personal workspace and are not supported for collaboration in shared workspaces.</Note>
 
 ## Create a workspace
 

--- a/documentation/features/workspaces.mdx
+++ b/documentation/features/workspaces.mdx
@@ -8,6 +8,8 @@ Once you are logged into Hoppscotch, you can toggle between multiple workspaces 
 
 You can choose between your workspace titled "**Personal Workspace**" or create a workspace for your teams so that you can collaborate.
 
+<Note>Currently, organizing requests across multiple shared workspaces is limited to RESTful protocol. GraphQL APIs are available only in personal workspaces and are not supported for collaboration in shared workspaces.</Note>
+
 ## Create a workspace
 
 To create a workspace, click on the **"+"** icon on the top right corner of the workspace switcher. Alternatively, you can also click on the "**Create new workspace**" button on the "[Profile](https://hoppscotch.io/profile)" page under the "**Workspaces**" section.


### PR DESCRIPTION
- [x] Added a note indicating that GraphQL APIs are limited to Personal Workspaces and are not available for collaboration in shared workspaces.