### PR TITLE
feat: info about SAML configurations

### DIFF
--- a/documentation/self-host/enterprise-edition/install-and-build.mdx
+++ b/documentation/self-host/enterprise-edition/install-and-build.mdx
@@ -355,6 +355,6 @@ When you use SAML authentication, by default Hoppscotch only pulls the email of 
 Starting from `v2024.9.2` onwards, Hoppscotch Enterprise Edition instances support pulling the following attributes from the SAML response to fill in additional user details:
 
 - `displayName`: The name of the user which is displayed within the Hoppscotch platform.
-- `photoURL`: The URL where to find the user's profile picture, do not set this attribute if a profile picture doesn't exist
+- `photoURL`: The URL where to find the user's profile picture. **Do not** set this attribute if a profile picture doesn’t exist.
 
 You have to configure your **SAML IdP (Identity Provider)** to include these attributes _exactly_ in the response. For example, for Okta, you can follow [this guide](https://support.okta.com/help/s/article/How-to-define-and-configure-a-custom-SAML-attribute-statement?language=en_US) to configure the attributes.

--- a/documentation/self-host/enterprise-edition/install-and-build.mdx
+++ b/documentation/self-host/enterprise-edition/install-and-build.mdx
@@ -357,4 +357,4 @@ Starting from `v2024.9.2` onwards, Hoppscotch Enterprise Edition instances suppo
 - `displayName`: The name of the user which is displayed within the Hoppscotch platform.
 - `photoURL`: The URL where to find the user's profile picture, do not set this attribute if a profile picture doesn't exist
 
-You have to configure your SAML IdP to include these attributes exactly in the response. For example, for Okta, you can follow [this guide](https://support.okta.com/help/s/article/How-to-define-and-configure-a-custom-SAML-attribute-statement?language=en_US) to configure the attributes.
+You have to configure your **SAML IdP (Identity Provider)** to include these attributes _exactly_ in the response. For example, for Okta, you can follow [this guide](https://support.okta.com/help/s/article/How-to-define-and-configure-a-custom-SAML-attribute-statement?language=en_US) to configure the attributes.

--- a/documentation/self-host/enterprise-edition/install-and-build.mdx
+++ b/documentation/self-host/enterprise-edition/install-and-build.mdx
@@ -352,7 +352,7 @@ To start saving the [audit logs](/guides/articles/audit-logs) into ClickHouse, f
    ```
 ## SAML Configuration
 When you use SAML authentication, by default Hoppscotch only pulls the email of the user as the platform uses it as the unique identifier to verify the user.
-Starting from v2024.9.2 onwards, Hoppscotch Enterprise Edition instances support pulling the following attributes from the SAML response to fill in additional user details:
+Starting from `v2024.9.2` onwards, Hoppscotch Enterprise Edition instances support pulling the following attributes from the SAML response to fill in additional user details:
 
 - `displayName`: The name of the user which is displayed within the Hoppscotch platform.
 - `photoURL`: The URL where to find the user's profile picture, do not set this attribute if a profile picture doesn't exist

--- a/documentation/self-host/enterprise-edition/install-and-build.mdx
+++ b/documentation/self-host/enterprise-edition/install-and-build.mdx
@@ -350,3 +350,11 @@ To start saving the [audit logs](/guides/articles/audit-logs) into ClickHouse, f
    ENGINE = MergeTree
    ORDER BY timestamp
    ```
+## SAML Configuration
+When you use SAML authentication, by default Hoppscotch only pulls the email of the user as the platform uses it as the unique identifier to verify the user.
+Starting from v2024.9.2 onwards, Hoppscotch Enterprise Edition instances support pulling the following attributes from the SAML response to fill in additional user details:
+
+- `displayName`: The name of the user which is displayed within the Hoppscotch platform.
+- `photoURL`: The URL where to find the user's profile picture, do not set this attribute if a profile picture doesn't exist
+
+You have to configure your SAML IdP to include these attributes exactly in the response. For example, for Okta, you can follow [this guide](https://support.okta.com/help/s/article/How-to-define-and-configure-a-custom-SAML-attribute-statement?language=en_US) to configure the attributes.


### PR DESCRIPTION
With v2024.9.2, Hoppscotch Enterprise Edition instances will support pulling additional user info from SAML authentication flows. This PR intends to documentation text to clear the info around that.