### PR TITLE
docs: Collection Runner, Uploading Binary files, CLI updates

### DIFF
--- a/documentation/clients/cli/overview.mdx
+++ b/documentation/clients/cli/overview.mdx
@@ -124,6 +124,24 @@ The JUnit report generated for collection runs provides a structured summary of 
 - `access token` : It is a secure, unique identifier used to authenticate a user's access to their Hoppscotch account and its resources like collections, environments data. [Learn more about personal access tokens](/documentation/features/pat)
 - `server url` : This optional and is the URL of your self-hosted instance when you're self-hosting your API client
 - `path` : Accounts for a file path where the JUnit report will be saved as an XML file in your file system.
+- `no_of_iterations`: Indicates the number of iterations to run the collection. Each iteration will run the entire collection once, replacing any iteration-specific data defined by the `--iteration-data` flag (if provided).
+  
+  ```bash
+  hopp test <hoppscotch_collection_file_or_id> [--iteration-count <no_of_iterations>] [--iteration-data <file_path>]
+  ```
+
+- `file_path`: The path to the CSV file for iteration data. This file should follow the format:
+    
+    ```
+    key1,key2,key3
+    value1,value2,value3
+    value4,value5,value6
+    ```
+    
+    Each row in the CSV corresponds to an iteration, and the values from that row will replace the respective environment variables during the iteration. For example:
+
+    - **Iteration 1:** The values value1, value2, and value3 will be used.
+    - **Iteration 2:** The values value4, value5, and value6 will be used.
 
 ### Example
 
@@ -134,6 +152,7 @@ hopp test -e environment.json -d 1000 kitchen-sink-hoppscotch-collection.json
 hopp test clxsntdgh0000lcx9fnits2h8 --token <access token> 
 hopp test -e clxspay2r0006lcx99aqgjbay -d 1000 clxsntdgh0000lcx9fnits2h8 --token <access token> --server http://localhost:3170
 hopp test -e environment.json kitchen-sink-hoppscotch-collection.json --reporter-junit kitchen-sink-junit.xml
+hopp test kitchen-sink-hoppscotch-collection.json --iteration-count 3 --iteration-data /path/to/iteration-data.csv
 ```
 
 ## Environment
@@ -195,6 +214,9 @@ If requests in a collection consists of secret variables we recommend either of 
 |`--token`                    | Expects a personal access token to be passed for establishing connection with your Hoppscotch account.            |
 |`--server`                   | URL of your self-hosted instance, if your collections are on a self-hosted instance.                              |
 |`--reporter-junit`           | Expects a file path to store the JUnit Report.                                                                    |    
+|`--iteration-count`          |	Defines the number of iterations to run the collection.                                                           |
+|`--iteration-data`	          | Accepts the path to a CSV file that contains iteration data.                                                      |             
+
 
 ## Test Report Components
 

--- a/documentation/features/runner.mdx
+++ b/documentation/features/runner.mdx
@@ -1,0 +1,46 @@
+---
+sidebarTitle: Runner
+title: Runner
+description: Iterate and execute your requests in a collection.
+---
+
+The Runner is a powerful tool that allows you to run a collection of requests sequentially. You can also configure the run settings to suit your needs.
+
+## Running a Collection
+
+To run a collection:
+
+- Right-click on the collection and select the "**Run Collection**" option.
+- Alternatively, hover over the collection name and click on the "**Run Collection**" icon.
+
+You can choose to run the collection from the CLI or through the web interface based on your preference. A new tab will open where you can configure the run settings as described below.
+
+## Run Settings
+
+1. **Delay**: Set an interval delay (in milliseconds) between running each request.
+2. **Stop Run if Error Occurs**: The collection run stops if an error is encountered within a script or if there's a problem sending a request.
+3. **Persist Responses**: Log response headers and bodies for review after running the collection. Note that persisting responses may impact performance for large collections.
+4. **Keep Variable Values**: Persist the variables used in the run, so any variables updated during the run will retain their changes after completion.
+
+## Executing the Run
+
+After setting up your preferences, start the collection runner. A new tab will display, showing real-time execution details, including:
+
+- **Collection**: The name of the collection being executed.
+- **Environment**: The active environment at runtime.
+- **Duration**: Total time taken to complete the run.
+- **Average Response Time**: The mean response time across all requests.
+
+### Running and Post-Run Actions
+
+- **Cancel Run**: Cancel the current run at any time.
+- **New Run**: Stop the current run and restart with new settings.
+- **Re-run**: When a run completes, you can restart with the same configurations as needed.
+
+## Runner Results
+
+The results view provides a comprehensive summary of your collection run, including:
+
+- **Request Status**: Success or failure of each request, along with HTTP status codes.
+- **Tests**: Detailed views of tests that passed or failed.
+- **Persisted Responses**: If enabled, view headers and bodies by selecting each request; otherwise, this section remains hidden.

--- a/documentation/getting-started/rest/uploading-data.mdx
+++ b/documentation/getting-started/rest/uploading-data.mdx
@@ -10,6 +10,7 @@ The most common content types are:
 
 - `application/json`: for content in JSON format
 - `multipart/form-data`: for uploading encoded files
+- `application/octet-stream`: for uploading binary data directly
 
 ## Uploading a file
 
@@ -24,3 +25,20 @@ To upload a file, the data you send in a `POST` request must be of the content t
 3. To add your image file click in the body tab and select `multipart/form-data` in the content-type dropdown.
 4. Give your file a name and click on `choose files` to select your file.
 5. Click "**Send**" to upload your file.
+
+### Set Content Type for individual part in `multipart/form-data`
+
+When sending multiple types of data in a single request using `multipart/form-data`, you can assign a specific content type to each part of the data in Hoppscotch. Here's how:
+1. Go to the **Body** tab and select `multipart/form-data` from the **Content Type** dropdown.
+2. Add the required data for your request by uploading files or entering values.
+3. To specify content types for individual parts, enable the **"Show Content Type"** option. Then, choose the appropriate content type for each part (e.g., `text/plain` for plain text or `application/json` for JSON data).
+4. Click **Send** to submit the multipart data, with each part using its respective content type.
+
+## Uploading Binary Data
+
+When uploading binary files, you may want to send raw binary data instead of files in a multipart form. This is typically done using the `application/octet-stream` content type. Follow these steps to upload binary data:
+
+1. Select the **POST** or **PUT** HTTP method and set your API Endpoint URL.
+2. In the **Body** tab, select `application/octet-stream` from the Content Type dropdown.
+3. Upload your binary data by selecting the file from your local machine.
+4. Click **Send** to upload the binary data.

--- a/mint.json
+++ b/mint.json
@@ -129,6 +129,7 @@
       "pages": [
         "documentation/features/workspaces",
         "documentation/features/collections",
+        "documentation/features/runner",
         "documentation/features/variables",
         "documentation/features/environments",
         "documentation/features/pat",


### PR DESCRIPTION
This PR addresses the updates related to Release v2024.11.0:
- [x] Introduced a new page for the Collection Runner.
- [x] Updated the CLI Overview page with descriptions for two new flags: `--iteration-count` and `--iteration-data`.
- [x] Added a section on specifying content types for individual parts when uploading `multipart/form-data`.
- [x] Included instructions for uploading binary files in the request body.
- [ ] One-click query and mutation generation feature in GraphQL (The finalized content will be added once I have a clear understanding of the feature’s positioning and functionality).