### PR TITLE
Update: Minimum Supported Node.js Version for CLI (v20)

### DIFF
--- a/documentation/clients/cli/overview.mdx
+++ b/documentation/clients/cli/overview.mdx
@@ -62,7 +62,7 @@ Once the dependencies are installed, install @hoppscotch/cli from npm by running
 npm i -g @hoppscotch/cli
 ```
 
-<Warning>The minimum supported Node.js version for the CLI is v18.</Warning>
+<Warning> The **minimum supported Node.js version** for the CLI is now **v20**. If you're using Node.js v18, you can continue with CLI `v0.11.1` until April 2025. Future CLI versions will require Node.js v20 or higher. </Warning>
 
 ## Commands
 

--- a/documentation/clients/cli/overview.mdx
+++ b/documentation/clients/cli/overview.mdx
@@ -62,8 +62,7 @@ Once the dependencies are installed, install @hoppscotch/cli from npm by running
 npm i -g @hoppscotch/cli
 ```
 
-<Warning> The **minimum supported Node.js version** for the CLI is now **v20**. If you're using Node.js v18, you can continue with CLI `v0.11.1` until April 2025. Future CLI versions will require Node.js v20 or higher. </Warning>
-
+<Warning> The **minimum supported Node.js version** for the CLI is now **v20**.  If you're on Node.js v18 (EOL in April, 2025), you can continue using CLI `v0.11.1`. Future CLI versions will require Node.js v20 or higher. </Warning>
 ## Commands
 
 ### `hopp test`


### PR DESCRIPTION
This PR updates the documentation to reflect the change in the minimum supported Node.js version for the Hoppscotch CLI. The minimum supported version is now **v20**, with continued support for Node.js v18 until April 2025 using CLI `v0.11.1`. 