### PR TITLE
update: add history configuration details on Admin Dashboard

### DIFF
--- a/documentation/self-host/community-edition/admin-dashboard.mdx
+++ b/documentation/self-host/community-edition/admin-dashboard.mdx
@@ -86,11 +86,11 @@ InfraTokens are special UUID tokens that provide a secure way for admins to inte
 
 Follow these steps to create a new InfraToken:
 
-1. After logging into your Self-Hosted instance using your admin credentials, you can access the **“Tokens”** under the **“Settings”** section from your admin dashboard.
-2. Click on **"Generate New InfraToken."**
+1. After logging into your Self-Hosted instance using your admin credentials, you can access the **“Infra Tokens”** under the **“Settings”** section from your admin dashboard.
+2. Click on **"Generate new token."**
 3. Enter a title for the token and select an expiration date. Available options include 7 days, 30 days, 60 days, 90 days, or no expiry.
 4. After providing the necessary details, confirm the creation. **The new InfraToken will be displayed once, make sure to copy it securely** to your clipboard for immediate use.
-5. If you decide that you no longer need the token, you can delete it by navigating back to **“Tokens"** section.
+5. If you decide that you no longer need the token, you can delete it by navigating back to **“Infra Tokens"** section.
 
 <Note> The details of the admin who created the InfraToken are stored for audit purposes. All admins can view and manage these tokens. </Note>
 
@@ -122,7 +122,19 @@ In the **Server Settings** section, you have the ability to both view and edit t
 2. **Configure SMTP Settings:**
    Set up your SMTP settings for seamless email integration.
 
-3. **Reset Configurations:**
+3. **History Configurations:**
+   Control the logging of request history for all users with a simple toggle option. 
+      
+      - **When enabled:** Request history is visible in the Hoppscotch app, and new entries are actively logged and stored in the database.
+      
+      - **When disabled:** Request history is hidden from the Hoppscotch app, and no new request logs are written to the database.
+      
+   You can also optionally choose to purge all existing history from the database, ensuring complete removal of previously logged request data.
+
+4. **Data sharing:**
+   Enable or disable anonymous data sharing to help improve Hoppscotch. [Learn more about the metrics collected](./telemetry).
+
+5. **Reset Configurations:**
    If needed, reset your configurations back to their original state.
 
 After making any configuration updates, be sure to save the changes. The server will automatically restart to apply the modifications.

--- a/documentation/self-host/enterprise-edition/admin-dashboard.mdx
+++ b/documentation/self-host/enterprise-edition/admin-dashboard.mdx
@@ -86,11 +86,11 @@ InfraTokens are special UUID tokens that provide a secure way for admins to inte
 
 Follow these steps to create a new InfraToken:
 
-1. After logging into your Self-Hosted instance using your admin credentials, you can access the **“Tokens”** under the “Settings” section from your admin dashboard.
-2. Click on **"Generate New InfraToken."**
+1. After logging into your Self-Hosted instance using your admin credentials, you can access the **“Infra Tokens”** under the “Settings” section from your admin dashboard.
+2. Click on **"Generate new token."**
 3. Enter a title for the token and select an expiration date. Available options include 7 days, 30 days, 60 days, 90 days, or no expiry.
 4. After providing the necessary details, confirm the creation. **The new InfraToken will be displayed once, make sure to copy it securely** to your clipboard for immediate use.
-5. If you decide that you no longer need the token, you can delete it by navigating back to **“Tokens"** section.
+5. If you decide that you no longer need the token, you can delete it by navigating back to **“Infra Tokens"** section.
 
 <Note> The details of the admin who created the InfraToken are stored for audit purposes. All admins can view and manage these tokens. </Note>
 
@@ -135,34 +135,50 @@ We’ve introduced new **APIs** to make **workspace management** and **collabora
 
 ## Server Settings
 
-### Access controls
+In the **Server Settings** section, you have the ability to both view and edit the environment variables that were configured during the setup of your self-hosted instance.
 
-1. **Site Protection:**
+### Configurations
+
+1. **Access Control Settings:** Manage and restrict user access to ensure only authorized users can interact with your Hoppscotch instance.
+
+   - **Site Protection:**
    When site protection is activated, all visitors to your Hoppscotch instance will be prompted to create an account and log in to use Hoppscotch. Site protection is enabled by default on Hoppscotch Enterprise and can be disabled as needed.
 
-2. **Domain Whitelisting:**
+   - **Domain Whitelisting:**
    Domain Whitelisting enables organization admins to grant access to users with email addresses under the organization’s domain without explicit approval.
 
    To enable domain whitelisting, activate the "Enable Whitelisted Domains" option and simply add the domains used by your organization for email addresses.
 
-### Authentication Providers
-
-1. **Configure Authentication Providers:**
+2. **Configure Authentication Providers:**
    Customize authentication providers, including Google, Microsoft, GitHub, and email, directly from the settings page.
-
-2. **Configure SAML Settings:**
-   Configure your SAML settings for your SAML based Single sign on.
 
 3. **Configure SMTP Settings:**
    Configure your SMTP settings for seamless email integration.
 
-4. **Configure OIDC Settings:**
+4. **Configure SAML Settings:**
+   Configure your SAML settings for your SAML based Single sign on.
+
+5. **Configure OIDC Settings:**
    Configure your OIDC Settings for Single Sign-On based authentication.
 
-5. **Configure Audit Logs Settings:**
-   Configure your Clickhouse settings for audit logs and download audit logs
+6. **Configure Audit Logs Settings:**
+   Configure your Clickhouse settings for audit logs and download audit logs.
 
-6. **Reset Configurations:**
+7. **History Configurations:**
+   Control the logging of request history for all users with a simple toggle option. 
+   
+   - **When enabled:**
+   Request history is visible in the Hoppscotch app, and new entries are actively logged and stored in the database.
+      
+   - **When disabled:**
+   Request history is hidden from the Hoppscotch app, and no new request logs are written to the database.
+   
+   You can also optionally choose to purge all existing history from the database, ensuring complete removal of previously logged request data.
+
+8. **Data sharing:**
+   Enable or disable anonymous data sharing to help improve Hoppscotch. [Learn more about the metrics collected](./telemetry).
+
+9. **Reset Configurations:**
    If needed, reset your configurations back to their original state.
 
 ### Custom Banner


### PR DESCRIPTION
This PR introduces a new section for configuring the Request History settings from the Admin Dashboard on both self-hosted editions, along with some minor fixes.