### PR TITLE
update: add a new "isAdmin" attribute to the SAML configuration settings.

### DIFF
--- a/documentation/self-host/enterprise-edition/install-and-build.mdx
+++ b/documentation/self-host/enterprise-edition/install-and-build.mdx
@@ -377,5 +377,14 @@ Starting from `v2024.9.2` onwards, Hoppscotch Enterprise Edition instances suppo
 
 - `displayName`: The name of the user which is displayed within the Hoppscotch platform.
 - `photoURL`: The URL where to find the user's profile picture. **Do not** set this attribute if a profile picture doesn’t exist.
+- `isAdmin` (optional): A boolean attribute (true or false) that automatically assigns the Admin role to users who belong to a designated group in the configured Identity Provider (e.g., Okta).
+
+<Note> The `isAdmin` attribute is evaluated only during the user's first login or signup. Subsequent logins or signups will not re-evaluate this flag. </Note>
+
+| Name         | Name Format | Value                                                       |
+| ------------ | ----------- | ------------------------------------------------------------|
+| displayName  | Basic       | user.displayName                                            |
+| photoURL     | Basic       | user.profileURL                                             |
+| isAdmin      | Basic       | isMemberOfGroupName("Hoppscotch Admins") ? "true" : "false" |
 
 You have to configure your **SAML IdP (Identity Provider)** to include these attributes _exactly_ in the response. For example, for Okta, you can follow [this guide](https://support.okta.com/help/s/article/How-to-define-and-configure-a-custom-SAML-attribute-statement?language=en_US) to configure the attributes.


### PR DESCRIPTION
This PR adds a new optional attribute (`isAdmin`) to the SAML Configuration settings. It also includes a table that explains the format and values for this attribute, making it easier to understand how to use it.