### PR TITLE
 Release v2024.12.0: GraphQL Query Generation, Bulk Edit for form-data, and "Keep Variable Values" Run Setting

### DIFF
--- a/documentation/features/runner.mdx
+++ b/documentation/features/runner.mdx
@@ -20,6 +20,7 @@ You can choose to run the collection from the CLI or through the web interface b
 1. **Delay**: Set an interval delay (in milliseconds) between running each request.
 2. **Stop Run if Error Occurs**: The collection run stops if an error is encountered within a script or if there's a problem sending a request.
 3. **Persist Responses**: Log response headers and bodies for review after running the collection. Note that persisting responses may impact performance for large collections.
+4. **Keep Variable Values**: Persist the variables used in the run, so any updates made to the variables during the run will retain their changes after completion.
 
 ## Executing the Run
 

--- a/documentation/getting-started/graphql/creating-a-query.mdx
+++ b/documentation/getting-started/graphql/creating-a-query.mdx
@@ -12,35 +12,39 @@ Switch to the GraphQL platform on Hoppscotch and connect to the below GraphQL se
 https://echo.hoppscotch.io/graphql
 ```
 
-Once a successful connection has been made, you can view both documentation and the schema using Hoppscotch.
+Once a successful connection has been made, you can view both **documentation** and the **schema** using Hoppscotch.
 
-It is important to explore the schema to understand the different queries, mutations, types, and subscriptions that are offered by the endpoint.
+It is important to explore the schema to understand the different **queries, mutations, types, and subscriptions** that are offered by the endpoint.
 
 ## Running the query
 
-Furthermore, you can run the query to fetch the data from the GraphQL server.
+You can execute queries to retrieve data from the GraphQL server by following these steps:
 
-## Naruto GraphQL endpoint
+- Navigate to the **Queries** subsection in the **Documentation** panel.
+- Select a query to automatically populate the Query editor with a structured template, pre-filled with required fields and arguments based on the API schema.
+- Customize the generated query as needed by adding or modifying fields, arguments, or variables directly in the Query editor.
+
+## Countries GraphQL endpoint
 
 Let's explore the Naruto GraphQL endpoint.
 
-1. Open Hoppscotch and connect to the endpoint below:
+1. Open Hoppscotch, switch to the GraphQL client and connect to the endpoint below:
 
     ```
-    https://narutoql.up.railway.app/graphql
+    https://countries.trevorblades.com/graphql
     ```
 
 2. Explore the schema and documentation to understand more about the endpoint.
-3. Write a query to get the character details whose name contains `hatake`.
+3. Look through the Queries section and add the `countries` query to the Query editor. Customize it to filter countries where the name is `"Germany"`.
 
     ```graphql
     {
-      characters(filter: {name: "hatake"}) {
-        results {
-        _id
-          name
-          village
-        }
+      countries (filter: {name: {eq: "Germany"}}) {
+        name
+        code
+        capital
+        emoji
+        currencies
       }
     }
     ```
@@ -51,20 +55,17 @@ Let's explore the Naruto GraphQL endpoint.
     ```json
     {
       "data": {
-        "characters": {
-          "results": [
-            {
-              "_id": "61bd1dbc918f12c17b9c64b5",
-              "name": "Hatake Kakashi",
-              "village": "leaf village"
-            },
-            {
-              "_id": "61bd1dbc918f12c17b9c64b6",
-              "name": "Hatake Sakumo",
-              "village": "leaf village"
-            }
-          ]
-        }
+        "countries": [
+          {
+            "name": "Germany",
+            "code": "DE",
+            "capital": "Berlin",
+            "emoji": "🇩🇪",
+            "currencies": [
+              "EUR"
+            ]
+          }
+        ]
       }
     }
     ```

--- a/documentation/getting-started/graphql/using-variables.mdx
+++ b/documentation/getting-started/graphql/using-variables.mdx
@@ -6,7 +6,7 @@ description: Learn how to use variables in a GraphQL query.
 
 Hoppscotch allows you to pass variables in the query to fetch data dynamically.
 
-To demonstrate the use of variables let's write a query to get the Ninja whose id is `61bd1dbc918f12c17b9c6483`.
+To demonstrate the use of variables, let’s write a query to get countries by their `name` and `continent`. For example, we will fetch the details of **Bahrain** from the **Asia** continent.
 
 ## Variables
 
@@ -14,38 +14,47 @@ Go to the variables section and define the variable.
 
 ```json
 {
-  "id": "61bd1dbc918f12c17b9c6483"
+  "countryName": "Bahrain",
+  "continentCode": "AS"
 }
 ```
 
 ## Using the variable in the query
 
-Now create a query `getCharacter` with variables as shown below:
+Now create a query `getCountries` with variables as shown below:
 
 ```graphql
- query getCharacter($id:String!){
-  character(id:$id) {
-    name
-    avatarSrc
-    rank
-    description
-    village
+  query getCountries($countryName: String!, $continentCode: String!) {
+    countries(filter: {name: {eq: $countryName}, continent: {eq: $continentCode}}) {
+      name
+      continent {
+        name
+      }
+      code
+      emoji
+      currencies
+    }
   }
-}
 ```
 
 Hoppscotch will retrieve the value of the variable and execute the query to get the below response.
 
 ```json
-{
-  "data": {
-    "character": {
-      "name": "Aburame Shibi",
-      "avatarSrc": "https://narutoql.s3.amazonaws.com/Aburame2.jpg",
-      "rank": "Jounin",
-      "description": "Aburame Shibi is the father of Aburame Shino. Like his son, his body is also inhabited by the destruction bugs.",
-      "village": "leaf village"
+  {
+    "data": {
+      "countries": [
+        {
+          "name": "Bahrain",
+          "continent": {
+            "name": "Asia"
+          },
+          "code": "BH",
+          "emoji": "🇧🇭",
+          "currencies": [
+            "BHD"
+          ]
+        }
+      ]
     }
   }
-}
 ```

--- a/documentation/getting-started/rest/tests.mdx
+++ b/documentation/getting-started/rest/tests.mdx
@@ -78,3 +78,19 @@ pw.test("Check first name", () => {
 ```
 
 Running the test will produce the result as shown below:
+
+```json
+  {
+    "data": {
+      "id": 10,
+      "email": "byron.fields@reqres.in",
+      "first_name": "Byron",
+      "last_name": "Fields",
+      "avatar": "https://reqres.in/img/faces/10-image.jpg"
+    },
+    "support": {
+      "url": "https://contentcaddy.io?utm_source=reqres&utm_medium=json&utm_campaign=referral",
+      "text": "Tired of writing endless social media content? Let Content Caddy generate it for you."
+    }
+  }
+```

--- a/documentation/getting-started/rest/uploading-data.mdx
+++ b/documentation/getting-started/rest/uploading-data.mdx
@@ -26,6 +26,8 @@ Let’s take a look at **uploading an image** file to an API using Hoppscotch:
 4. Give your file a name and click on `choose files` to select your file.
 5. Click "**Send**" to upload your file.
 
+The <Icon icon="pen-to-square" iconType="solid" />  **Bulk Edit** feature is available for `multipart/form-data` as well. Instead of adding or editing key-value pairs one by one, you can now manage them all at once.
+
 ### Set Content Type for Specific Parameters in `multipart/form-data`
 
 When sending multiple types of data in a single request using `multipart/form-data`, you can assign a specific content type to each parameter in Hoppscotch. Here’s how:


### PR DESCRIPTION
**This PR includes updates planned for `v2024.12.0`:**

- [x] Added Bulk Edit feature context for `multipart/form-data`.
- [x] Updated the GraphQL Query Generation flow under the [Running the Query](https://docs.hoppscotch.io/documentation/getting-started/graphql/creating-a-query#running-the-query) section.
- [x] Replaced the Naruto API example with the Countries API example due to the Naruto API no longer being functional.
- [x] Included the `Keep Variable Values` run setting for the Collection Runner.
- [x] Updated the [Tests](https://docs.hoppscotch.io/documentation/getting-started/rest/tests#assert-response-payload) page to include the previously missing response.