### PR TITLE
update: revised note on accessing User and Workspace Management APIs

### DIFF
--- a/documentation/self-host/community-edition/admin-dashboard.mdx
+++ b/documentation/self-host/community-edition/admin-dashboard.mdx
@@ -76,7 +76,7 @@ The RESTful APIs designed for User Management enable **admins** to perform a wid
 | Manage Admin Status | Enables admins to add or remove admin status for an existing user. | PATCH | `<base-url>/v1/infra/users/{uid}/admin-status` | 
 | Fetch User’s involvement in Workspaces | Retrieves workspace details that a user is part of, including their role. | GET | `<base-url>/v1/infra/users/{uid}/workspaces` |
 
-<Info> To interact with the **User Management APIs**, ensure that your backend service is running, either on your local machine or on a server. The API documentation is accessible at the `/api-docs` endpoint relative to your backend service URL. For example, if your backend is running locally, you can access the API docs at [http://localhost:3170/api-docs](http://localhost:3170/api-docs). </Info>
+<Info> To interact with the **User Management APIs**, ensure that your backend service is running, either on your local machine or on a server. The API documentation is accessible at the `/api-docs` endpoint relative to your backend service URL. For example, if your backend is running locally, you can access the API docs at [http://localhost:3170/api-docs](http://localhost:3170/api-docs). You can also retrieve the OpenAPI v3 JSON format at [http://localhost:3170/api-docs-json](http://localhost:3170/api-docs-json). </Info>
 
 ### InfraTokens
 

--- a/documentation/self-host/community-edition/admin-dashboard.mdx
+++ b/documentation/self-host/community-edition/admin-dashboard.mdx
@@ -76,7 +76,7 @@ The RESTful APIs designed for User Management enable **admins** to perform a wid
 | Manage Admin Status | Enables admins to add or remove admin status for an existing user. | PATCH | `<base-url>/v1/infra/users/{uid}/admin-status` | 
 | Fetch User’s involvement in Workspaces | Retrieves workspace details that a user is part of, including their role. | GET | `<base-url>/v1/infra/users/{uid}/workspaces` |
 
-<Info> To view the User Management API specifications, please visit our **[Swagger Documentation](https://stage-shc.hoppscotch.io/backend/api-docs)**. </Info>
+<Info> To interact with the **User Management APIs**, ensure that your backend service is running, either on your local machine or on a server. The API documentation is accessible at the `/api-docs` endpoint relative to your backend service URL. For example, if your backend is running locally, you can access the API docs at [http://localhost:3170/api-docs](http://localhost:3170/api-docs). </Info>
 
 ### InfraTokens
 

--- a/documentation/self-host/enterprise-edition/admin-dashboard.mdx
+++ b/documentation/self-host/enterprise-edition/admin-dashboard.mdx
@@ -76,7 +76,7 @@ The RESTful APIs designed for User Management enable **admins** to perform a wid
 | Manage Admin Status | Enables admins to add or remove admin status for an existing user. | PATCH | `<base-url>/v1/infra/users/{uid}/admin-status` | 
 | Fetch User’s involvement in Workspaces | Retrieves workspace details that a user is part of, including their role. | GET | `<base-url>/v1/infra/users/{uid}/workspaces` |
 
-<Info> To interact with the **User Management APIs**, ensure that your backend service is running, either on your local machine or on a server. The API documentation is accessible at the `/api-docs` endpoint relative to your backend service URL. For example, if your backend is running locally, you can access the API docs at [http://localhost:3170/api-docs](http://localhost:3170/api-docs). </Info>
+<Info> To interact with the **User Management APIs**, ensure that your backend service is running, either on your local machine or on a server. The API documentation is accessible at the `/api-docs` endpoint relative to your backend service URL. For example, if your backend is running locally, you can access the API docs at [http://localhost:3170/api-docs](http://localhost:3170/api-docs). You can also retrieve the OpenAPI v3 JSON format at [http://localhost:3170/api-docs-json](http://localhost:3170/api-docs-json). </Info>
 
 ### Infra-tokens
 
@@ -131,7 +131,7 @@ We’ve introduced new **APIs** to make **workspace management** and **collabora
 | View all pending workspace invites. | List all pending invites for workspace access. | GET | `<base-url>/v1/infra/workspaces/{id}/ invitations` |
 | Delete pending workspace invites. | Revoke Workspace invitations using invitation IDs. | DELETE | `<base-url>/v1/infra/workspaces/{id}/ invitations/{invitation_id}` |
 
-<Info> To interact with the **Workspace Management APIs**, ensure that your backend service is running, either on your local machine or on a server. The API documentation is accessible at the `/api-docs` endpoint relative to your backend service URL. For example, if your backend is running locally, you can access the API docs at [http://localhost:3170/api-docs](http://localhost:3170/api-docs). </Info>
+<Info> To interact with the **Workspace Management APIs**, ensure that your backend service is running, either on your local machine or on a server. The API documentation is accessible at the `/api-docs` endpoint relative to your backend service URL. For example, if your backend is running locally, you can access the API docs at [http://localhost:3170/api-docs](http://localhost:3170/api-docs). You can also retrieve the OpenAPI v3 JSON format at [http://localhost:3170/api-docs-json](http://localhost:3170/api-docs-json). </Info>
 
 ## Server Settings
 

--- a/documentation/self-host/enterprise-edition/admin-dashboard.mdx
+++ b/documentation/self-host/enterprise-edition/admin-dashboard.mdx
@@ -76,7 +76,7 @@ The RESTful APIs designed for User Management enable **admins** to perform a wid
 | Manage Admin Status | Enables admins to add or remove admin status for an existing user. | PATCH | `<base-url>/v1/infra/users/{uid}/admin-status` | 
 | Fetch User’s involvement in Workspaces | Retrieves workspace details that a user is part of, including their role. | GET | `<base-url>/v1/infra/users/{uid}/workspaces` |
 
-<Info> To view the User Management API specifications, please visit our **[Swagger Documentation](https://stage-she.hoppscotch.io/backend/api-docs)**. </Info>
+<Info> To interact with the **User Management APIs**, ensure that your backend service is running, either on your local machine or on a server. The API documentation is accessible at the `/api-docs` endpoint relative to your backend service URL. For example, if your backend is running locally, you can access the API docs at [http://localhost:3170/api-docs](http://localhost:3170/api-docs). </Info>
 
 ### Infra-tokens
 
@@ -131,7 +131,7 @@ We’ve introduced new **APIs** to make **workspace management** and **collabora
 | View all pending workspace invites. | List all pending invites for workspace access. | GET | `<base-url>/v1/infra/workspaces/{id}/ invitations` |
 | Delete pending workspace invites. | Revoke Workspace invitations using invitation IDs. | DELETE | `<base-url>/v1/infra/workspaces/{id}/ invitations/{invitation_id}` |
 
-<Info> To know more about the Workspace Management API specifications, please visit our **[Swagger Documentation](https://stage-she.hoppscotch.io/backend/api-docs)**. </Info>
+<Info> To interact with the **Workspace Management APIs**, ensure that your backend service is running, either on your local machine or on a server. The API documentation is accessible at the `/api-docs` endpoint relative to your backend service URL. For example, if your backend is running locally, you can access the API docs at [http://localhost:3170/api-docs](http://localhost:3170/api-docs). </Info>
 
 ## Server Settings
 


### PR DESCRIPTION
Since the Swagger documentation hosted at staging instances is no longer maintained, this update revises the note to clearly guide users on how to access the User Management and Workspace Management APIs directly through the `/api-docs` endpoint.