### PR TITLE
update: note for Request Header Description Fields

### DIFF
--- a/documentation/getting-started/rest/request-headers.mdx
+++ b/documentation/getting-started/rest/request-headers.mdx
@@ -20,7 +20,7 @@ Here are a few common headers you might set:
 | **Cache-Control** | Controls caching behavior in both requests and responses.                                 |
 | **User-Agent**    | Provides information about the client making the request.                                 |
 
-<Note> For **Authorization and Content-Type** headers, the description field will be disabled, and the value will be empty. In contrast, for **inherited headers**, the specified values will be automatically populated in the description field. </Note>
+<Note> When the **Authorization and Content-Type** values are set through their respective sections, the description fields in their auto-generated headers are disabled for manual input, leaving the value empty. In contrast, for **Inherited** headers, the specified values are automatically populated in the description fields. </Note>
 
 Hoppscotch offers a variety of header options beyond these five examples, allowing you to customize how the server processes your requests to meet specific requirements.
 


### PR DESCRIPTION
Fixes #274 

This PR clarifies the behavior of the description fields for the Authorization and Content-Type headers