### PR TITLE
update: new REDIS variable for horizontal scaling

### DIFF
--- a/documentation/self-host/enterprise-edition/install-and-build.mdx
+++ b/documentation/self-host/enterprise-edition/install-and-build.mdx
@@ -37,7 +37,7 @@ HORIZONTAL_SCALING=false
 
 # Redis Config 
 # Note: Configure Redis only if HORIZONTAL_SCALING is set to true
-REDIS_URL=redis://username:password@hoppscotch-redis:6379/0
+REDIS_URL=redis://username:password@host:6379/0
 
 # Auth Tokens Config
 JWT_SECRET=secretcode123


### PR DESCRIPTION
This PR introduces a new environment variable, `REDIS_URL`, to simplify Redis configuration for horizontal scaling, replacing the previous Redis-related variables. Also, a warning has been added to highlight this breaking change and encourage users to update their `.env` file accordingly.