### PR TITLE
add: Helm Chart Instructions for Deploying Hoppscotch on Kubernetes

### DIFF
--- a/documentation/self-host/getting-started.mdx
+++ b/documentation/self-host/getting-started.mdx
@@ -13,6 +13,9 @@ This section will help you get started with self-hosting your instance of Hoppsc
   <Card title="Enterprise Edition" iconType="light" icon="circle-arrow-right" href="/documentation/self-host/enterprise-edition/getting-started">
     SAML-based SSO, on-prem deployment, audit logs, and more. Hoppscotch Enterprise Edition is a self-hosted version of Hoppscotch Cloud with enterprise-ready features for teams and organizations.
   </Card>
+  <Card title="Helm Chart Deployment" iconType="light" icon="circle-arrow-right" href="/documentation/self-host/helm-chart-deployment/getting-started"> 
+    Helm chart offers a quick and automated way to set up Hoppscotch on your infrastructure. Perfect for Kubernetes environments, it ensures scalability and simplifies the management of your instance.  
+</Card> 
 </CardGroup>
 
 <Info>Hoppscotch Enterprise Edition is available for on-premise deployment with priority support. [Contact Hoppscotch Support](/support/getting-started/contact)</Info>

--- a/documentation/self-host/helm-chart-deployment/digital-ocean.mdx
+++ b/documentation/self-host/helm-chart-deployment/digital-ocean.mdx
@@ -76,7 +76,7 @@ Follow the steps below to deploy Hoppscotch on your DigitalOcean Kubernetes clus
     image:
       repository: hoppscotch/hoppscotch  
       tag: latest  
-    pullPolicy: IfNotPresent  
+      pullPolicy: IfNotPresent  
     
     urls:
       base: "http://frontend.yourdomain.com"

--- a/documentation/self-host/helm-chart-deployment/digital-ocean.mdx
+++ b/documentation/self-host/helm-chart-deployment/digital-ocean.mdx
@@ -1,0 +1,185 @@
+---
+sidebarTitle: Digital Ocean
+title: Digital Ocean
+description: Install and configure Hoppscotch on Digital Ocean using Helm Charts for cloud-based deployment.
+---
+
+[DigitalOcean](https://www.digitalocean.com/) is a cloud provider that offers scalable and easy-to-use infrastructure for developers. You can create and manage Kubernetes clusters, storage, and networking resources all through their platform.
+
+With DigitalOcean’s managed Kubernetes service and Helm charts, deploying Hoppscotch on your infrastructure becomes a plain sailing process.
+
+## Pre-requisites
+
+Before you begin, make sure you have the following tools and services set up:
+
+### Digital Ocean Account
+
+To deploy Hoppscotch on DigitalOcean, you will need a DigitalOcean account. If you don't have an account already, sign up for one [here](https://www.digitalocean.com/).
+
+#### - **Kubernetes Cluster Access**
+    You need an active Kubernetes cluster on DigitalOcean. If you don’t have one already, you can easily create a cluster through the DigitalOcean Dashboard.
+#### - **Administrative Permissions**
+    Ensure that your user account has administrative access to manage the Kubernetes cluster. This is important for performing actions like deploying applications, managing configurations, and troubleshooting issues.
+
+### **Command Line Tools**
+
+You’ll need a few essential command-line tools installed and configured on your local machine to interact with your Kubernetes cluster and deploy applications.
+
+#### - **`kubectl` CLI**
+    `kubectl` is the Kubernetes command-line tool that allows you to interact with your Kubernetes cluster. If you don’t have `kubectl` installed, follow the instructions in the [official Kubernetes documentation](https://kubernetes.io/docs/tasks/tools/) to get started.
+#### - **Helm `version 3.x`**
+    Helm is a package manager for Kubernetes, which simplifies the deployment and management of applications like Hoppscotch. Helm uses **charts**, which are pre-configured application definitions, to deploy applications to Kubernetes clusters. To install Helm, follow the [Helm installation guide](https://helm.sh/docs/intro/install/).
+
+## Installation and Deployment
+
+Follow the steps below to deploy Hoppscotch on your DigitalOcean Kubernetes cluster:
+
+<Steps>
+  <Step title="Digital Ocean Cluster Connection">
+        To authenticate your cluster, you’ll need the kubeconfig file from DigitalOcean.
+    
+    1. Go to your **DigitalOcean Dashboard**.
+    2. Navigate to **Kubernetes** > **Clusters**.
+    3. Select the Kubernetes cluster that you want to deploy Hoppscotch on.
+    4. Click **Download Config File**. The file will be named `[cluster-name]-kubeconfig.yaml` and will typically be saved in your `Downloads` folder.
+  </Step>
+  <Step title="Configure access to the Cluster">
+    Once you have the kubeconfig file, set it up to enable communication between `kubectl` and your DigitalOcean Kubernetes cluster:
+    
+    ```bash
+    # Set KUBECONFIG environment variable to use the downloaded config file
+    export KUBECONFIG=~/Downloads/[cluster-name]-kubeconfig.yaml
+    
+    # Verify the connection by listing the nodes in the cluster
+    kubectl get nodes
+    ```
+    
+    <Tip> To avoid reconfiguring the `KUBECONFIG` variable every time you interact with the cluster, move the kubeconfig file to a more permanent location (e.g., `~/.kube/config`) and add the `export` command to your shell's configuration file (`.bashrc`, `.zshrc`, etc.)  for persistent access. </Tip>
+  </Step>
+  <Step title="Install NGINX Ingress Controller (Optional)">
+    If you need to expose Hoppscotch to external traffic via an `HTTP/S` interface, you will need an Ingress Controller. [NGINX](https://nginx.org/) is a popular choice for this.
+    
+    To install the NGINX Ingress Controller on your Kubernetes cluster, execute:
+    
+    ```bash
+    kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.8.2/deploy/static/provider/do/deploy.yaml
+    ```
+    
+    This will create the necessary resources (e.g., deployments, services) to enable ingress routing for your cluster.
+  </Step>
+  <Step title="Configure and Prepare the `values.yaml` File">
+    Helm charts use a `values.yaml` file to customize the deployment. You'll need to modify the `values.yaml` file to suit your environment:
+    
+    ```yaml
+    replicaCount: 2  
+    
+    image:
+      repository: hoppscotch/hoppscotch  
+      tag: latest  
+      pullPolicy: IfNotPresent  
+    
+    urls:
+      frontend: "<https://frontend.yourdomain.com>"
+      backend: "<https://backend.yourdomain.com>"
+      admin: "<https://admin.yourdomain.com>"  
+    
+    service:
+      type: LoadBalancer  
+      port: 3000  
+    
+    ingress:
+      enabled: true  
+      hosts:
+        - host: <frontend.yourdomain.com>  
+    
+    # If using Hoppscotch Enterprise, configure your license key
+    enterprise:
+      licenseKey: "1e8xxxxx-fexx-49xx-8cxx-d57f54fxxxxx"
+    
+    ```
+  </Step>
+  <Step title="Deploy Hoppscotch on Kubernetes">
+    Now that you’ve configured the `values.yaml` file, you’re ready to deploy Hoppscotch using Helm.
+    
+    ```bash
+    # Clone the repository
+    git clone <https://github.com/hoppscotch/helm-charts.git>
+    
+    # Go to helm charts directory
+    cd helm-charts
+    
+    # Install the chart for community edition
+    helm install community-hoppscotch ./charts/shc
+    
+    # Install the chart for enterprise edition
+    helm install enterprise-hoppscotch ./charts/she
+    ```
+    
+    This will start the deployment of Hoppscotch with the configuration you set in the `values.yaml` file.
+  </Step>
+</Steps>
+
+## **Verification**
+
+After deploying the application, verify that everything is running smoothly by checking the status of your Hoppscotch pods and inspecting the service details, including the external IP or LoadBalancer that you'll use to access the application.
+
+```bash
+# List all the pods running in the cluster
+kubectl get pods
+
+# View services to ensure that Hoppscotch is exposed properly
+kubectl get services
+```
+
+## Setup and Access
+After successfully deploying Hoppscotch and verifying the installation, the next step is to set up the Admin Dashboard and then access the Hoppscotch application for API development and testing.
+
+### Create an Administrator account
+1. Open a new browser tab and visit `https://admin.yourdomain.com`.
+2. Login with your credentials or create a new account.
+3. Upon successful login, the Admin Dashboard will be accessible, letting you manage configurations and perform administrative tasks.
+
+<Info> The first user to log in will automatically be granted administrator privileges. </Info>
+
+### Access the Hoppscotch app
+With the administrator account set up, you can now start using the Hoppscotch app:
+1. Open a new browser tab and visit `https://frontend.yourdomain.com`.
+2. Begin developing and testing your APIs seamlessly with Hoppscotch.
+
+## Management
+
+Below are some commands to help you with ongoing management tasks for your deployment.
+
+### **Update Configuration**
+
+To apply changes to the configuration (for example, modifying the `values.yaml` file), use the following command to upgrade the deployment:
+
+```bash
+# Upgrade the chart for community edition
+helm upgrade community-hoppscotch ./charts/shc -f ./charts/values.yaml
+
+# Upgrade the chart for enterprise edition
+helm upgrade enterprise-hoppscotch ./charts/she -f ./charts/values.yaml
+```
+
+### **Remove Installation**
+
+To uninstall Hoppscotch and clean up the resources, you can remove both community and enterprise editions: 
+
+```bash
+# Uninstall the community edition
+helm uninstall community-hoppscotch
+
+# Uninstall the enterprise edition
+helm uninstall enterprise-hoppscotch
+```
+
+## Troubleshooting
+
+If you encounter issues during or after the installation, the following commands can help diagnose the problem:
+
+| Issue                     | Command to Check                                   |
+| ------------------------  | -------------------------------------------------- |
+| **Pod Issues**            | `kubectl logs [POD_NAME]`                          |
+| **Service Status**        | `kubectl describe service community-hoppscotch` <br />   `kubectl describe service enterprise-hoppscotch` |
+| **Configuration Issues**  | `kubectl describe configmap community-hoppscotch` <br /> `kubectl describe configmap enterprise-hoppscotch` |

--- a/documentation/self-host/helm-chart-deployment/digital-ocean.mdx
+++ b/documentation/self-host/helm-chart-deployment/digital-ocean.mdx
@@ -79,9 +79,9 @@ Follow the steps below to deploy Hoppscotch on your DigitalOcean Kubernetes clus
       pullPolicy: IfNotPresent  
     
     urls:
-      frontend: "<https://frontend.yourdomain.com>"
-      backend: "<https://backend.yourdomain.com>"
-      admin: "<https://admin.yourdomain.com>"  
+      frontend: "https://frontend.yourdomain.com"
+      backend: "https://backend.yourdomain.com"
+      admin: "https://admin.yourdomain.com"  
     
     service:
       type: LoadBalancer  
@@ -90,7 +90,7 @@ Follow the steps below to deploy Hoppscotch on your DigitalOcean Kubernetes clus
     ingress:
       enabled: true  
       hosts:
-        - host: <frontend.yourdomain.com>  
+        - host: frontend.yourdomain.com  
     
     # If using Hoppscotch Enterprise, configure your license key
     enterprise:
@@ -103,7 +103,7 @@ Follow the steps below to deploy Hoppscotch on your DigitalOcean Kubernetes clus
     
     ```bash
     # Clone the repository
-    git clone <https://github.com/hoppscotch/helm-charts.git>
+    git clone https://github.com/hoppscotch/helm-charts.git
     
     # Go to helm charts directory
     cd helm-charts

--- a/documentation/self-host/helm-chart-deployment/digital-ocean.mdx
+++ b/documentation/self-host/helm-chart-deployment/digital-ocean.mdx
@@ -71,26 +71,33 @@ Follow the steps below to deploy Hoppscotch on your DigitalOcean Kubernetes clus
     Helm charts use a `values.yaml` file to customize the deployment. You'll need to modify the `values.yaml` file to suit your environment:
     
     ```yaml
-    replicaCount: 2  
+    replicaCount: 1  
     
     image:
       repository: hoppscotch/hoppscotch  
       tag: latest  
-      pullPolicy: IfNotPresent  
+    pullPolicy: IfNotPresent  
     
     urls:
-      frontend: "https://frontend.yourdomain.com"
-      backend: "https://backend.yourdomain.com"
-      admin: "https://admin.yourdomain.com"  
+      base: "http://frontend.yourdomain.com"
+      shortcode: "http://frontend.yourdomain.com"
+      admin: "http://admin.yourdomain.com"
+      backend:
+        gql: "http://backend.yourdomain.com/graphql"
+        ws: "ws://backend.yourdomain.com/graphql"
+        api: "http://backend.yourdomain.com/v1"
+      redirect: "http://frontend.yourdomain.com"
+      whitelistedOrigins: "http://backend.yourdomain.com,http://frontend.yourdomain.com,http://admin.yourdomain.com"
     
     service:
       type: LoadBalancer  
       port: 3000  
     
     ingress:
-      enabled: true  
-      hosts:
-        - host: frontend.yourdomain.com  
+      enabled: true
+      mainHost: frontend.yourdomain.com
+      adminHost: admin.yourdomain.com
+      backendHost: backend.yourdomain.com  
     
     # If using Hoppscotch Enterprise, configure your license key
     enterprise:

--- a/documentation/self-host/helm-chart-deployment/digital-ocean.mdx
+++ b/documentation/self-host/helm-chart-deployment/digital-ocean.mdx
@@ -17,7 +17,7 @@ Before you begin, make sure you have the following tools and services set up:
 To deploy Hoppscotch on DigitalOcean, you will need a DigitalOcean account. If you don't have an account already, sign up for one [here](https://www.digitalocean.com/).
 
 #### - **Kubernetes Cluster Access**
-    You need an active Kubernetes cluster on DigitalOcean. If you don’t have one already, you can easily create a cluster through the DigitalOcean Dashboard.
+    You need an active Kubernetes cluster on DigitalOcean. If you don’t have one already, you can easily create a cluster through the **DigitalOcean Dashboard**.
 #### - **Administrative Permissions**
     Ensure that your user account has administrative access to manage the Kubernetes cluster. This is important for performing actions like deploying applications, managing configurations, and troubleshooting issues.
 
@@ -67,7 +67,7 @@ Follow the steps below to deploy Hoppscotch on your DigitalOcean Kubernetes clus
     
     This will create the necessary resources (e.g., deployments, services) to enable ingress routing for your cluster.
   </Step>
-  <Step title="Configure and Prepare the `values.yaml` File">
+  <Step title="Configure and Prepare the 'values.yaml' File">
     Helm charts use a `values.yaml` file to customize the deployment. You'll need to modify the `values.yaml` file to suit your environment:
     
     ```yaml
@@ -97,6 +97,8 @@ Follow the steps below to deploy Hoppscotch on your DigitalOcean Kubernetes clus
       licenseKey: "1e8xxxxx-fexx-49xx-8cxx-d57f54fxxxxx"
     
     ```
+
+    <Note> If you are deploying Hoppscotch Enterprise edition, you'll need a valid license key. To obtain one, visit the [Hoppscotch Enterprise Store](https://enterprise.hoppscotch.com/) and make a purchase. After completing the purchase, you’ll receive an email with the license key. Alternatively, you can find the key in your Hoppscotch Enterprise Dashboard. For more details on managing your license key, refer to this [guide](/guides/articles/manage-an-enterprise-license-key). </Note>
   </Step>
   <Step title="Deploy Hoppscotch on Kubernetes">
     Now that you’ve configured the `values.yaml` file, you’re ready to deploy Hoppscotch using Helm.
@@ -114,8 +116,6 @@ Follow the steps below to deploy Hoppscotch on your DigitalOcean Kubernetes clus
     # Install the chart for enterprise edition
     helm install enterprise-hoppscotch ./charts/she
     ```
-    
-    This will start the deployment of Hoppscotch with the configuration you set in the `values.yaml` file.
   </Step>
 </Steps>
 

--- a/documentation/self-host/helm-chart-deployment/getting-started.mdx
+++ b/documentation/self-host/helm-chart-deployment/getting-started.mdx
@@ -1,0 +1,17 @@
+---
+sidebarTitle: Getting Started
+title: Getting Started
+description: Deploy Hoppscotch on Kubernetes with Helm charts for a scalable and efficient self-hosting solution.
+---
+
+Deploying Hoppscotch (both [Community](/documentation/self-host/community-edition/getting-started) and [Enterprise](/documentation/self-host/enterprise-edition/getting-started) editions) with **Helm charts** makes it easier to manage your self-hosted instance on [Kubernetes](https://kubernetes.io/). 
+
+[Helm]((https://helm.sh/)) is a package manager for Kubernetes, and [charts](https://artifacthub.io/) are pre-configured templates that automate the deployment and management of applications on Kubernetes. By using Helm, you can quickly spin up a fully functional Hoppscotch instance on your cloud provider or local Kubernetes setup.
+
+For detailed instructions, you can explore the pages below:
+
+<CardGroup cols={1}>
+    <Card title="DigitalOcean" iconType="light" icon="digital-ocean" href="/documentation/self-host/helm-chart-deployment/digital-ocean">
+        Deploy Hoppscotch on DigitalOcean using their managed Kubernetes service and Helm charts and optimize resource management for your self-hosted Hoppscotch instance.    
+    </Card>
+</CardGroup>

--- a/mint.json
+++ b/mint.json
@@ -180,6 +180,13 @@
             "documentation/self-host/enterprise-edition/deploy-and-upgrade",
             "documentation/self-host/enterprise-edition/telemetry"
           ]
+        },
+        {
+          "group": "Helm Chart Deployment",
+          "pages": [
+            "documentation/self-host/helm-chart-deployment/getting-started",
+            "documentation/self-host/helm-chart-deployment/digital-ocean"
+          ]
         }
       ]
     },


### PR DESCRIPTION
This PR caters to Helm chart instructions that can be used for deploying a self-hosted Hoppscotch instance on Kubernetes.