### PR TITLE
Change pnpm command for Prisma migration

### DIFF
--- a/documentation/self-host/community-edition/install-and-build.mdx
+++ b/documentation/self-host/community-edition/install-and-build.mdx
@@ -213,7 +213,7 @@ docker run -it --entrypoint sh --env-file .env <container_name>
 Making sure to pass in the `.env` file containing the right `.env` variables for the instance. On executing the aforementioned command will result in a shell being opened inside a instance of the container following which user can execute a database migration normally with
 
 ```bash
-pnpm dlx prisma migrate deploy
+pnpm exec prisma migrate deploy
 ```
 
 Once the database has been successfully run and the database populated with tables the backend containers ( or AIO container) can be started normally.

--- a/documentation/self-host/enterprise-edition/install-and-build.mdx
+++ b/documentation/self-host/enterprise-edition/install-and-build.mdx
@@ -219,7 +219,7 @@ docker exec -it <container_id> /bin/sh
 Once inside the container, run the migration using:
 
 ```bash
-pnpm dlx prisma migrate deploy
+pnpm exec prisma migrate deploy
 ```
 
 Should the user ever encounter the following error:
@@ -237,7 +237,7 @@ docker run -it --entrypoint sh --env-file .env <container_name>
 Making sure to pass in the `.env` file containing the right `.env` variables for the instance. On executing the aforementioned command will result in a shell being opened inside a instance of the container following which user can execute a database migration normally with
 
 ```bash
-pnpm dlx prisma migrate deploy
+pnpm exec prisma migrate deploy
 ```
 
 Once the database has been successfully run and the database populated with tables the backend containers ( or AIO container) can be started normally.

--- a/guides/articles/self-host-hoppscotch-on-your-own-servers.mdx
+++ b/guides/articles/self-host-hoppscotch-on-your-own-servers.mdx
@@ -199,7 +199,7 @@ Once the environment variables are configured, you may now proceed to the next s
     
     ```jsx
     docker run -it --entrypoint sh --env-file .env hoppscotch/hoppscotch
-    # pnpm dlx prisma migrate deploy
+    # pnpm exec prisma migrate deploy
     ```
   </Step>
   <Step title="Start the Hoppscotch Instance">


### PR DESCRIPTION
Updated command to use 'pnpm exec' instead of 'pnpm dlx' for running Prisma migrations.