### PR TITLE
Improve inspections documentation clarity

### DIFF
--- a/documentation/features/inspections.mdx
+++ b/documentation/features/inspections.mdx
@@ -4,10 +4,10 @@ title: Inspections
 description: Use Hoppscotch inspections to detect misconfigured API request inputs like missing headers, parameters, or auth settings before sending.
 ---
 
-Hoppscotch inspections offer a powerful solution for debugging API requests, assisting in reducing errors due to misconfigured user inputs. 
+Hoppscotch Inspections help you identify and fix configuration issues in your API requests before sending them. They detect common problems such as missing headers, parameters, or authentication settings.
 
-Hoppscotch inspections are designed to streamline the process of identifying and rectifying errors stemming from improperly configured API request inputs. When an input section within the application is not properly configured, Inspections will visually alert users by displaying an alert icon. This icon serves as an indicator that potential issues are present in the configuration.
+When a request section is not configured correctly, Inspections displays an alert icon to notify you about potential issues. Clicking the alert icon opens the Inspections panel, which provides details about the problem and suggestions to resolve it.
 
 ## Inspecting Configuration Errors
 
-Upon clicking the alert icon, the Inspections panel will provide an overview of possible configuration errors that might be hindering the accomplishment of your intended goal and ways to resolve the errors.
+The Inspections panel provides an overview of configuration errors that may prevent your request from working as expected and offers guidance on how to fix them.


### PR DESCRIPTION
## Summary

- Improved the Inspections documentation wording
- Removed repetitive explanations
- Made the documentation clearer and easier to understand for users

## Changes Made

- Simplified the introduction section
- Combined repeated information into a concise explanation
- Improved the description of configuration errors and solutions

## Related Issue

Closes #353