### PR TITLE
docs(mcp-server): overview, tools, and troubleshooting pages

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -86,6 +86,14 @@
                   "documentation/clients/cli/overview",
                   "documentation/clients/cli/troubleshooting"
                 ]
+              },
+              {
+                "group": "MCP server",
+                "pages": [
+                  "documentation/clients/mcp-server/overview",
+                  "documentation/clients/mcp-server/tools",
+                  "documentation/clients/mcp-server/troubleshooting"
+                ]
               }
             ]
           },

--- a/documentation/clients/mcp-server/overview.mdx
+++ b/documentation/clients/mcp-server/overview.mdx
@@ -89,7 +89,7 @@ Register the server with your host. The command and arguments are the same every
   </Tab>
 </Tabs>
 
-<Note>Only Claude Desktop publishes a fixed configuration path. For any other host, check its own documentation.</Note>
+<Note>Claude Code and Codex register the server through their own CLI, so you never need to know where they keep their configuration. Claude Desktop has no such command, which is why its file path is given above. For any other host, check its own documentation.</Note>
 
 ### Pointing at a self-hosted instance
 
@@ -254,7 +254,7 @@ Below, CRUD is shorthand for the four basic operations on a resource: create, re
 
 | Profile | Tools | Contents |
 | --- | --- | --- |
-| `minimal` | 22 | Collection and environment CRUD for personal and team workspaces, plus `reauth`. |
+| `minimal` | 22 | Collection and environment CRUD for personal and team workspaces, collection import and export, plus `reauth`. |
 | `core` (default) | 39 | Everything in `minimal`, plus request CRUD, request execution, code generation, and read-only team discovery. |
 | `standard` | 38 | Everything in `minimal`, plus team administration and advanced collection operations such as duplicate, move, import, and search. |
 | `full` | 53 | Every tool. |

--- a/documentation/clients/mcp-server/overview.mdx
+++ b/documentation/clients/mcp-server/overview.mdx
@@ -141,7 +141,7 @@ If the server does not appear at all, see [Troubleshooting](/documentation/clien
 
 ## Authentication
 
-You do not configure a token. The server signs you in through your browser the first time an agent calls a tool.
+The first tool call that reaches your Hoppscotch account signs you in. The server uses `HOPPSCOTCH_ACCESS_TOKEN` if you set one, then a cached session, and opens your browser only when neither is available. Tools that never touch your account, such as `generate_code`, `generate_documentation`, and `execute_request` with no `environmentId`, do not sign you in at all.
 
 <Steps>
   <Step title="A local callback server starts">
@@ -158,7 +158,7 @@ You do not configure a token. The server signs you in through your browser the f
   </Step>
 </Steps>
 
-From then on, refreshes happen on their own before anything expires: through the backend on self-hosted, and through a stored Firebase refresh token on Cloud, where sessions run about an hour. You are only sent back to the browser if a refresh fails.
+From then on, refreshes happen on their own before anything expires: through the backend on self-hosted, and through a stored Firebase refresh token on Cloud, where sessions run about an hour. You are sent back to the browser when a refresh fails, and equally when there is no cached session, when the cached one belongs to a different account, or when the credentials needed to refresh are missing.
 
 <Warning>Automatic refresh applies only to the browser-login session cached in `auth.json`. A token you supply through `HOPPSCOTCH_ACCESS_TOKEN` is used exactly as given and is **never refreshed**. It keeps whatever expiry it was issued with, about an hour for a Cloud token and about a day for a self-hosted one, and stops working once that passes. Plan to rotate it.</Warning>
 
@@ -170,7 +170,7 @@ One identity per operating-system user, shared by every MCP host process you run
 
 ### Running without a browser
 
-CI runners, containers, and SSH sessions have no browser, so device login has nothing to open. Rather than hang, the server spots these environments and fails straight away with guidance.
+CI runners and SSH sessions have no browser, so device login has nothing to open. Rather than hang, the server spots them and fails straight away with guidance. Detection keys on `CI`, on `SSH_CONNECTION` or `SSH_TTY`, and on Linux with neither `DISPLAY` nor `WAYLAND_DISPLAY`, so a container that sets none of those is not caught.
 
 Work around it in three steps:
 
@@ -254,9 +254,9 @@ Below, CRUD is shorthand for the four basic operations on a resource: create, re
 
 | Profile | Tools | Contents |
 | --- | --- | --- |
-| `minimal` | 22 | Collection and environment CRUD for personal and team workspaces, collection import and export, plus `reauth`. |
+| `minimal` | 22 | Collection and environment CRUD for personal and team workspaces, personal collection import, team and personal collection export, plus `reauth`. |
 | `core` (default) | 39 | Everything in `minimal`, plus request CRUD, request execution, code generation, and read-only team discovery. |
-| `standard` | 38 | Everything in `minimal`, plus team administration and advanced collection operations such as duplicate, move, import, and search. |
+| `standard` | 38 | Everything in `minimal`, plus team administration, advanced collection operations such as duplicate, move, import, and search, and read-only team discovery through `list_teams` and `get_team_info`. |
 | `full` | 53 | Every tool. |
 
 <Note>`core` and `standard` are **separate branches** of `full`, not a ladder. `standard` is not a superset of `core`. Moving from `core` to `standard` **removes request execution, response validation, code generation, and request CRUD**, and adds team administration in their place. Use `full` if you need both.</Note>

--- a/documentation/clients/mcp-server/overview.mdx
+++ b/documentation/clients/mcp-server/overview.mdx
@@ -1,0 +1,340 @@
+---
+sidebarTitle: Overview
+title: Hoppscotch MCP Server
+description: Connect AI agents to Hoppscotch with the MCP server. Includes install steps, host setup for Claude and Codex, authentication, and configuration.
+---
+
+The Model Context Protocol (MCP) is an open standard that lets an AI assistant call external tools through a running server. Whatever application you run the assistant in, such as Claude Desktop, is the **host**.
+
+Hoppscotch ships an MCP server of its own. It hands the host your collections, requests, environments, and teams, so an agent can read and change them for you. It also sends real HTTP requests: ask it to test an endpoint and it runs the request, brings the response back into the conversation, and can check the result against criteria you describe.
+
+Everything happens over stdio, so the host launches the server as a local process and talks to it over standard input and output. It ships as a command-line binary. There is no library to import.
+
+For the AI features built into the Hoppscotch app itself, see [AI features](/documentation/features/ai-features).
+
+## Pre-requisites
+
+- **Node.js v22 or higher**
+- An MCP host, such as Claude Desktop, Claude Code, or Codex
+- A Hoppscotch account on [Cloud](https://hoppscotch.io) or a self-hosted instance
+
+## Installing the MCP server
+
+You usually do not install anything. The registration in [Connecting your MCP host](#connecting-your-mcp-host) goes through `npx`, which fetches and runs the current version on demand, and your host starts it for you.
+
+If you would rather have it on disk, install it globally. That also gives you the `hoppscotch-mcp` binary:
+
+```bash
+npm install -g @hoppscotch/mcp-server
+```
+
+Building from source works too:
+
+```bash
+git clone https://github.com/hoppscotch/hoppscotch-mcp-server.git
+cd hoppscotch-mcp-server
+pnpm install
+pnpm run build
+```
+
+<Note>Released builds carry the Firebase Web API key that Cloud sign-in needs. A build from source does not. To use Cloud from a source build, set `HOPPSCOTCH_FIREBASE_API_KEY` at build time or in your host's `env` block, where the runtime value takes precedence. Self-hosted instances do not use Firebase and need nothing extra.</Note>
+
+## Connecting your MCP host
+
+Register the server with your host. The command and arguments are the same everywhere. Only the registration syntax changes.
+
+<Tabs>
+  <Tab title="Claude Code">
+    Register it for every project on your machine:
+
+    ```bash
+    claude mcp add -s user hoppscotch -- npx -y @hoppscotch/mcp-server
+    ```
+
+    Drop `-s user` to register it for the current project only. Claude Code also reads a project-scoped `.mcp.json` using the same `mcpServers` shape shown in the Claude Desktop tab.
+  </Tab>
+
+  <Tab title="Codex">
+    Register it from your terminal:
+
+    ```bash
+    codex mcp add hoppscotch -- npx -y @hoppscotch/mcp-server
+    ```
+  </Tab>
+
+  <Tab title="Claude Desktop">
+    Edit `~/Library/Application Support/Claude/claude_desktop_config.json` on macOS, or `%APPDATA%\Claude\claude_desktop_config.json` on Windows:
+
+    ```json
+    {
+      "mcpServers": {
+        "hoppscotch": {
+          "command": "npx",
+          "args": ["-y", "@hoppscotch/mcp-server"]
+        }
+      }
+    }
+    ```
+  </Tab>
+
+  <Tab title="Other hosts">
+    Any host that can run a stdio MCP server works. Register it with whatever syntax your host uses, supplying:
+
+    | Field | Value |
+    | --- | --- |
+    | Command | `npx` |
+    | Arguments | `-y`, `@hoppscotch/mcp-server` |
+
+    Configuration file locations and formats vary between hosts, so check your host's own documentation for where to put this.
+  </Tab>
+</Tabs>
+
+<Note>Only Claude Desktop publishes a fixed configuration path. For any other host, check its own documentation.</Note>
+
+### Pointing at a self-hosted instance
+
+Set `HOPPSCOTCH_SERVER_URL` when you register the server. Every variable in [Configuration](#configuration) is set the same way.
+
+<Tabs>
+  <Tab title="Claude Code">
+    ```bash
+    claude mcp add -s user hoppscotch \
+      -e HOPPSCOTCH_SERVER_URL=https://your-hoppscotch.example.com \
+      -- npx -y @hoppscotch/mcp-server
+    ```
+  </Tab>
+
+  <Tab title="Codex">
+    ```bash
+    codex mcp add hoppscotch \
+      --env HOPPSCOTCH_SERVER_URL=https://your-hoppscotch.example.com \
+      -- npx -y @hoppscotch/mcp-server
+    ```
+  </Tab>
+
+  <Tab title="Config file">
+    ```json
+    {
+      "mcpServers": {
+        "hoppscotch": {
+          "command": "npx",
+          "args": ["-y", "@hoppscotch/mcp-server"],
+          "env": {
+            "HOPPSCOTCH_SERVER_URL": "https://your-hoppscotch.example.com"
+          }
+        }
+      }
+    }
+    ```
+  </Tab>
+</Tabs>
+
+<Note>Claude Code takes environment variables with `-e`, Codex with `--env`. Both expect them before the `--` that separates the registration from the command to run.</Note>
+
+### Confirming it is connected
+
+Restart the host after registering. Most hosts read MCP configuration only at startup.
+
+In Claude Code and Codex, run the `/mcp` command. It should list `hoppscotch` as **Enabled**. Then try a prompt such as "list all collections in my Hoppscotch workspace", which triggers the sign-in described below.
+
+If the server does not appear at all, see [Troubleshooting](/documentation/clients/mcp-server/troubleshooting#the-server-does-not-appear-in-your-host).
+
+## Authentication
+
+You do not configure a token. The server signs you in through your browser the first time an agent calls a tool.
+
+<Steps>
+  <Step title="A local callback server starts">
+    A temporary HTTP listener comes up on a random port, bound to loopback, so it accepts connections from your own machine and nowhere else.
+  </Step>
+  <Step title="Your browser opens the device-login page">
+    You land on `<HOPPSCOTCH_SERVER_URL>/device-login`, carrying a redirect back to that local port and a random single-use value that ties the answer to this request.
+  </Step>
+  <Step title="You sign in">
+    Once you do, the page hands your tokens to the local callback.
+  </Step>
+  <Step title="The session is cached">
+    Those tokens land in `~/.config/hoppscotch-mcp/auth.json` and get reused, so later calls skip the browser entirely.
+  </Step>
+</Steps>
+
+From then on, refreshes happen on their own before anything expires: through the backend on self-hosted, and through a stored Firebase refresh token on Cloud, where sessions run about an hour. You are only sent back to the browser if a refresh fails.
+
+<Warning>Automatic refresh applies only to the browser-login session cached in `auth.json`. A token you supply through `HOPPSCOTCH_ACCESS_TOKEN` is used exactly as given and is **never refreshed**. It keeps whatever expiry it was issued with, about an hour for a Cloud token and about a day for a self-hosted one, and stops working once that passes. Plan to rotate it.</Warning>
+
+You get five minutes to finish signing in. That is how long the local callback stays open, it is fixed in the code, and no environment variable moves it. `HOPPSCOTCH_AUTH_TIMEOUT_MS` is a different clock: it decides how long one tool call waits before handing you the login URL and asking you to try again. Pushing it past `300000` buys you nothing, since the callback shuts first.
+
+<Warning>On macOS and Linux, `auth.json` is written with owner-only permissions (`0600`). **On Windows these permissions are not enforced.** Treat the file as a live credential and keep it somewhere only you can read.</Warning>
+
+One identity per operating-system user, shared by every MCP host process you run and kept across restarts. There is no way to pick an identity per call. Should the token on disk change to a different account mid-session, the server stops rather than quietly acting as someone else, and `reauth` is how you switch or refresh.
+
+### Running without a browser
+
+CI runners, containers, and SSH sessions have no browser, so device login has nothing to open. Rather than hang, the server spots these environments and fails straight away with guidance.
+
+Work around it in three steps:
+
+1. Complete a device login once on a machine that does have a browser.
+2. Copy the `accessToken` value out of `~/.config/hoppscotch-mcp/auth.json`.
+3. Set `HOPPSCOTCH_ACCESS_TOKEN` to it in the headless environment.
+
+Treat what you copied as short-lived. Nothing refreshes it, and it carries whatever expiry it was issued with, roughly an hour on Cloud and a day on self-hosted, so plan the rotation.
+
+<Note>`HOPPSCOTCH_ACCESS_TOKEN` must be a Hoppscotch **JWT**, the token type issued by device login. A Hoppscotch personal access token (`pat-...`) works only against REST endpoints, not the GraphQL API this server uses, so it **will not work here.**</Note>
+
+If a browser is available but detection gets it wrong, set `HOPPSCOTCH_FORCE_BROWSER_LOGIN=true`.
+
+## Configuration
+
+The server reads twelve `HOPPSCOTCH_` configuration variables, and most setups need none of them. Cloud is the default, and browser login handles authentication.
+
+The login step separately inspects `CI`, `SSH_CONNECTION`, `SSH_TTY`, `DISPLAY`, and `WAYLAND_DISPLAY` to decide whether a browser can be opened. You do not set these yourself, but their presence changes behavior. See [Running without a browser](#running-without-a-browser).
+
+### Commonly set
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `HOPPSCOTCH_SERVER_URL` | `https://hoppscotch.io` | Frontend URL of your instance. Omit for Cloud. The API URL and the Cloud or self-hosted mode are both derived from it. |
+| `HOPPSCOTCH_TOOL_PROFILE` | `core` | Which tools are exposed. One of `minimal`, `core`, `standard`, or `full`. See [Tool profiles](#tool-profiles). |
+| `HOPPSCOTCH_DEFAULT_TEAM_ID` | none | Team ID used by team-scoped tools when the call omits one. |
+
+### Headless and non-interactive use
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `HOPPSCOTCH_ACCESS_TOKEN` | none | A Hoppscotch JWT that skips browser login. A `pat-...` token does not work. |
+| `HOPPSCOTCH_FORCE_BROWSER_LOGIN` | `false` | Set `true` to attempt browser login even when a headless environment is detected. |
+| `HOPPSCOTCH_AUTH_TIMEOUT_MS` | `60000` | How long one tool call waits for sign-in before returning the login URL and retry guidance. The local callback stays open for up to five minutes, a fixed window with no override, so values above `300000` have no effect. |
+
+### Request execution
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `HOPPSCOTCH_TIMEOUT` | `30000` | Default request timeout in milliseconds. A call can override it with its own `timeout` between 1,000 and 120,000. This variable itself is only checked for being positive, so set it deliberately. |
+| `HOPPSCOTCH_MAX_RESPONSE_BYTES` | `5000000` | Cap on the response body the server buffers. Larger responses are truncated and flagged. |
+| `HOPPSCOTCH_ALLOW_PRIVATE_HOSTS` | `false` | Set `true` to let `execute_request` and `validate_response` reach addresses on your own machine or private network. Only on trusted input. See [Security](#security). |
+
+### Hardening
+
+Both are off by default, so behavior is unchanged unless you set them.
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `HOPPSCOTCH_SECRET_ALLOWED_ORIGINS` | none | Comma-separated origins allowed to receive secret environment values through `{{variable}}` substitution. **Unset means no restriction**, so secrets substitute freely. Set it to opt in, after which a secret referenced in a request to any other origin is refused. An origin is scheme, host, and port with no path, for example `https://api.example.com,https://staging.example.com:8443`. An entry that is not an absolute URL is discarded without warning, so `api.example.com` contributes nothing and can leave the list empty. |
+| `HOPPSCOTCH_STRICT_ENV` | `false` | Set `true` to ignore trust-sensitive variables that a working-directory `.env` file introduces. See [Hardening a .env setup](#hardening-a-env-setup). |
+
+### Building from source
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `HOPPSCOTCH_FIREBASE_API_KEY` | baked in at build | Firebase Web API key used for Cloud sign-in. Released builds bake it in, so you normally never set this. Set it when building from source and using Cloud. Not used by self-hosted instances. |
+
+### Hardening a .env setup
+
+By default the server honors a `.env` file in its working directory for every variable above except `HOPPSCOTCH_STRICT_ENV` itself, which is read from the real environment before the `.env` loads so that a `.env` cannot switch it off. If your host opens repositories you do not control, a `.env` committed to one of them could repoint the backend, widen the tool surface, or allowlist an origin that may receive your secrets.
+
+Set `HOPPSCOTCH_STRICT_ENV=true` in your host's `env` block to close that off. Eleven trust-sensitive variables are then ignored when a `.env` introduces them, and must come from the real process environment instead:
+
+| Group | Variables |
+| --- | --- |
+| Auth target and credential | `HOPPSCOTCH_SERVER_URL`, `HOPPSCOTCH_ACCESS_TOKEN`, `HOPPSCOTCH_FIREBASE_API_KEY` |
+| Security toggles | `HOPPSCOTCH_ALLOW_PRIVATE_HOSTS`, `HOPPSCOTCH_SECRET_ALLOWED_ORIGINS`, `HOPPSCOTCH_TOOL_PROFILE` |
+| Login behavior | `HOPPSCOTCH_AUTH_TIMEOUT_MS`, `HOPPSCOTCH_FORCE_BROWSER_LOGIN` |
+| Write target and limits | `HOPPSCOTCH_DEFAULT_TEAM_ID`, `HOPPSCOTCH_MAX_RESPONSE_BYTES`, `HOPPSCOTCH_TIMEOUT` |
+
+A value you set in the real environment is preserved. Only a value the `.env` introduces is stripped. `HOPPSCOTCH_STRICT_ENV` itself is the switch and is not in the list.
+
+<Note>Strict mode protects these eleven variables. It does not sanitize the rest of the environment. A `.env` can still set unrelated variables that the server reads, such as `CI`, which makes the login step treat the machine as headless and refuse to open a browser.</Note>
+
+## Tool profiles
+
+There are 53 tools in total, and `HOPPSCOTCH_TOOL_PROFILE` decides how many of them your host ever sees. Whatever the profile leaves out is invisible to discovery and refused at call time, so an agent cannot reach a tool by naming it directly.
+
+Below, CRUD is shorthand for the four basic operations on a resource: create, read, update, and delete.
+
+| Profile | Tools | Contents |
+| --- | --- | --- |
+| `minimal` | 22 | Collection and environment CRUD for personal and team workspaces, plus `reauth`. |
+| `core` (default) | 39 | Everything in `minimal`, plus request CRUD, request execution, code generation, and read-only team discovery. |
+| `standard` | 38 | Everything in `minimal`, plus team administration and advanced collection operations such as duplicate, move, import, and search. |
+| `full` | 53 | Every tool. |
+
+<Note>`core` and `standard` are **separate branches** of `full`, not a ladder. `standard` is not a superset of `core`. Moving from `core` to `standard` **removes request execution, response validation, code generation, and request CRUD**, and adds team administration in their place. Use `full` if you need both.</Note>
+
+Set the variable to something it does not recognize and you get `core` back, plus a warning on the server's error output. It never falls through to `full`, so a one-character typo cannot hand an agent the destructive team-administration surface.
+
+For which profile includes which tool, see [Tools](/documentation/clients/mcp-server/tools).
+
+## Cloud and self-hosted
+
+Point it at a self-hosted instance, Community or Enterprise, and everything works. Cloud is the uneven one. Its personal workspace is gated there for now, but that gate lives in this server rather than in the backend, and it was never applied to every tool, so the result is not a clean on or off.
+
+| Capability | Cloud | Self-hosted |
+| --- | --- | --- |
+| Team collections, requests, and environments | Supported | Supported |
+| Team administration | Supported | Supported |
+| Request execution and response validation | Supported | Supported |
+| Code and documentation generation | Supported | Supported |
+| Personal collections and requests, reading | Not supported | Supported |
+| Personal collections and requests, writing | **Runs** | Supported |
+| Personal environments | Not supported | Supported |
+| `search_team_requests` | Not supported | Supported |
+
+<Warning>On Cloud, personal collection and request **writes are not blocked, but the matching reads are.** An agent can create a personal collection and then be unable to list it back. Use team workspaces on Cloud.</Warning>
+
+For the exact behavior of every affected tool, see [Cloud behavior](/documentation/clients/mcp-server/tools#cloud-behavior).
+
+Which mode you land in comes from `HOPPSCOTCH_SERVER_URL`. Only `hoppscotch.io` and `www.hoppscotch.io` count as Cloud and route to `api.hoppscotch.io`. Anything else is treated as self-hosted, and calls go to `<your-url>/backend`.
+
+## Security
+
+This server acts with your Hoppscotch credentials and puts real HTTP requests on the wire. Here is what that means in practice, and where the defaults leave you exposed.
+
+### Request execution reaches the public internet
+
+`execute_request` and `validate_response` are general-purpose HTTP clients, and by default they refuse anything that resolves to your own machine or a private network instead of the open internet. That sweep covers loopback, private ranges, and the special-use ranges behind link-local addressing, carrier-grade NAT, and cloud metadata endpoints like `169.254.169.254`, in IPv4, IPv6, and the mixed forms. Protection of this kind is usually called an SSRF guard, short for server-side request forgery.
+
+A few details make it harder to slip past. If name resolution errors, the call is blocked rather than allowed through. The address that passed the check is pinned at connect time, so nothing can swap it out in between. And redirects are never followed, which stops a permitted host from bouncing your credentials somewhere else with a `3xx`.
+
+<Warning>These protections stop internal targets, not public ones. `execute_request` can still reach **any public host your machine can reach, using the credentials in the request**. Treat a request the agent composed with the same care as one you wrote.</Warning>
+
+Set `HOPPSCOTCH_ALLOW_PRIVATE_HOSTS=true` only to test a local or self-hosted API, and only on input you trust. It skips the private-address checks and the connect-time revalidation for these two tools. The restriction to `http` and `https` still applies, and the server's own traffic to your Hoppscotch backend is never affected either way. The response headers and up to `HOPPSCOTCH_MAX_RESPONSE_BYTES` of the body are returned into the model's context.
+
+### Destructive tools run immediately
+
+<Warning>The server implements **no confirmation step.** A `delete_` tool or a team-membership change takes effect on the first call. The default `core` profile includes `delete_team_collection`, `delete_team_environment`, and the personal equivalents, so an agent on a default install can delete a shared team collection. What `core` withholds is team *administration*, such as deleting a team or removing a member.</Warning>
+
+Every tool does carry four MCP annotation hints, `readOnlyHint`, `destructiveHint`, `idempotentHint`, and `openWorldHint`, and a host is free to prompt you based on them. Whether it bothers is the host's call, not this server's.
+
+Do not lean on them too hard. They are assigned from the tool-name prefix, which makes them blunter than they appear: `update_team_member_role`, along with every `rename_` and `update_` tool, advertises `destructiveHint: false`. A host that only prompts on the destructive hint will let a role change or an overwrite through without asking. Shrink the surface with `HOPPSCOTCH_TOOL_PROFILE=minimal`, and check [Tools](/documentation/clients/mcp-server/tools) for what each profile holds.
+
+### Secret variables
+
+Environment values marked secret are masked in environment listings. When such a value is substituted into a request, the server also scrubs it from the response body, headers, and error text before the model sees it.
+
+Do not lean on that for confidentiality. Scrubbing matches the forms a secret takes when it is sent, so a target that reshapes the value before echoing it, or a value your request truncated on the way out, comes back unredacted. And only values flagged secret are tracked in the first place: a plain variable, a credential in the `auth` block, or anything typed straight into a header was never a candidate. [What scrubbing covers](/documentation/clients/mcp-server/tools#what-scrubbing-covers) has the exact behavior.
+
+Secrets substitute into requests to any origin unless you say otherwise. `HOPPSCOTCH_SECRET_ALLOWED_ORIGINS` is how you narrow that.
+
+### Generated code carries live credentials
+
+<Warning>`generate_code` returns a runnable snippet with **live credential values** by default. Pass `redactCredentials: true` to mask them. `generate_documentation` is the opposite and masks by default. Check which tool produced output before sharing it.</Warning>
+
+Masking only reaches so far. It handles the structured `auth` object, headers and query parameters whose names look credential-bearing, and JSON or form-encoded body fields. An XML, plain-text, multipart, or binary body it leaves alone entirely, and a credential sitting in a field it does not recognize stays put. Read what came out before you paste it anywhere, masked or not.
+
+### What the server does not do
+
+Past scrubbing the secret environment values it substituted, nothing redacts response bodies. Personal data and anything else sensitive in a response arrives in the model's context as-is, and applying a redaction or approval policy on top is the host's job.
+
+There is also no hosted or multi-tenant mode. Running this as a publicly reachable HTTP server is out of scope.
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Tools" iconType="light" icon="circle-arrow-right" href="/documentation/clients/mcp-server/tools">
+    Every tool, what it does, and which profiles include it.
+  </Card>
+  <Card title="Troubleshooting" iconType="light" icon="circle-arrow-right" href="/documentation/clients/mcp-server/troubleshooting">
+    Errors you may see, what causes them, and how to fix them.
+  </Card>
+</CardGroup>

--- a/documentation/clients/mcp-server/overview.mdx
+++ b/documentation/clients/mcp-server/overview.mdx
@@ -305,7 +305,7 @@ Set `HOPPSCOTCH_ALLOW_PRIVATE_HOSTS=true` only to test a local or self-hosted AP
 
 Every tool does carry four MCP annotation hints, `readOnlyHint`, `destructiveHint`, `idempotentHint`, and `openWorldHint`, and a host is free to prompt you based on them. Whether it bothers is the host's call, not this server's.
 
-Do not lean on them too hard. They are assigned from the tool-name prefix, which makes them blunter than they appear: `invite_team_member` is additive in shape, so it advertises `destructiveHint: false`, yet it accepts a role of `OWNER`. A host that only prompts on the destructive hint will let an ownership grant through without asking. That one needs `standard` or `full`. Shrink the surface with `HOPPSCOTCH_TOOL_PROFILE=minimal`, and check [Tools](/documentation/clients/mcp-server/tools) for what each profile holds.
+Do not lean on them too hard. They are assigned from the tool-name prefix, with a few hand-written exceptions, which makes them blunter than they appear: `invite_team_member` is additive in shape, so it advertises `destructiveHint: false`, yet it accepts a role of `OWNER`. A host that only prompts on the destructive hint will let an ownership grant through without asking. That one needs `standard` or `full`. Shrink the surface with `HOPPSCOTCH_TOOL_PROFILE=minimal`, and check [Tools](/documentation/clients/mcp-server/tools) for what each profile holds.
 
 ### Secret variables
 

--- a/documentation/clients/mcp-server/overview.mdx
+++ b/documentation/clients/mcp-server/overview.mdx
@@ -306,7 +306,7 @@ Set `HOPPSCOTCH_ALLOW_PRIVATE_HOSTS=true` only to test a local or self-hosted AP
 
 Every tool does carry four MCP annotation hints, `readOnlyHint`, `destructiveHint`, `idempotentHint`, and `openWorldHint`, and a host is free to prompt you based on them. Whether it bothers is the host's call, not this server's.
 
-Do not lean on them too hard. They are assigned from the tool-name prefix, which makes them blunter than they appear: `update_team_member_role`, along with every `rename_` and `update_` tool, advertises `destructiveHint: false`. A host that only prompts on the destructive hint will let a role change or an overwrite through without asking. Shrink the surface with `HOPPSCOTCH_TOOL_PROFILE=minimal`, and check [Tools](/documentation/clients/mcp-server/tools) for what each profile holds.
+Do not lean on them too hard. They are assigned from the tool-name prefix, which makes them blunter than they appear: `invite_team_member` is additive in shape, so it advertises `destructiveHint: false`, yet it accepts a role of `OWNER`. A host that only prompts on the destructive hint will let an ownership grant through without asking. That one needs `standard` or `full`. Shrink the surface with `HOPPSCOTCH_TOOL_PROFILE=minimal`, and check [Tools](/documentation/clients/mcp-server/tools) for what each profile holds.
 
 ### Secret variables
 

--- a/documentation/clients/mcp-server/overview.mdx
+++ b/documentation/clients/mcp-server/overview.mdx
@@ -267,20 +267,19 @@ For which profile includes which tool, see [Tools](/documentation/clients/mcp-se
 
 ## Cloud and self-hosted
 
-Point it at a self-hosted instance, Community or Enterprise, and everything works. Cloud is the uneven one. Its personal workspace is gated there for now, but that gate lives in this server rather than in the backend, and it was never applied to every tool, so the result is not a clean on or off.
+All 53 tools are available against a self-hosted instance, Community or Enterprise. On Cloud, this server refuses `get_user_collection`, and the backend rejects `search_team_requests`. Every other personal-workspace tool is available there, reads included.
 
 | Capability | Cloud | Self-hosted |
 | --- | --- | --- |
-| Team collections, requests, and environments | Supported | Supported |
+| Other team collection, request, and environment tools | Supported | Supported |
 | Team administration | Supported | Supported |
 | Request execution and response validation | Supported | Supported |
 | Code and documentation generation | Supported | Supported |
-| Personal collections and requests, reading | Not supported | Supported |
-| Personal collections and requests, writing | **Runs** | Supported |
-| Personal environments | Not supported | Supported |
+| Other personal collection, request, and environment tools | Supported | Supported |
+| `get_user_collection` | Not supported | Supported |
 | `search_team_requests` | Not supported | Supported |
 
-<Warning>On Cloud, personal collection and request **writes are not blocked, but the matching reads are.** An agent can create a personal collection and then be unable to list it back. Use team workspaces on Cloud.</Warning>
+<Note>`get_user_collection` is the one personal-workspace tool that refuses to run on Cloud. The check was added after Cloud's `userCollection` resolver failed to serialize the `data` field, which fails the whole query. For root-level collections use `list_user_collections`; for a known ID, including a nested one, use `export_user_collection`, which works on Cloud but returns export JSON rather than the collection envelope.</Note>
 
 For the exact behavior of every affected tool, see [Cloud behavior](/documentation/clients/mcp-server/tools#cloud-behavior).
 

--- a/documentation/clients/mcp-server/overview.mdx
+++ b/documentation/clients/mcp-server/overview.mdx
@@ -158,7 +158,7 @@ The first tool call that reaches your Hoppscotch account signs you in. The serve
   </Step>
 </Steps>
 
-From then on, refreshes happen on their own before anything expires: through the backend on self-hosted, and through a stored Firebase refresh token on Cloud, where sessions run about an hour. You are sent back to the browser when a refresh fails, and equally when there is no cached session, when the cached one belongs to a different account, or when the credentials needed to refresh are missing.
+From then on, refreshes happen on their own before anything expires: through the backend on self-hosted, and through a stored Firebase refresh token on Cloud, where sessions run about an hour. Browser login starts again when there is no usable cached session, meaning no stored token, or an expired one with no refresh credential to renew it. A cached token belonging to a **different** account is refused rather than replaced, with an error telling you to run `reauth` to switch identities.
 
 <Warning>Automatic refresh applies only to the browser-login session cached in `auth.json`. A token you supply through `HOPPSCOTCH_ACCESS_TOKEN` is used exactly as given and is **never refreshed**. It keeps whatever expiry it was issued with, about an hour for a Cloud token and about a day for a self-hosted one, and stops working once that passes. Plan to rotate it.</Warning>
 
@@ -170,7 +170,7 @@ One identity per operating-system user, shared by every MCP host process you run
 
 ### Running without a browser
 
-CI runners and SSH sessions have no browser, so device login has nothing to open. Rather than hang, the server spots them and fails straight away with guidance. Detection keys on `CI`, on `SSH_CONNECTION` or `SSH_TTY`, and on Linux with neither `DISPLAY` nor `WAYLAND_DISPLAY`, so a container that sets none of those is not caught.
+CI runners and SSH sessions have no browser, so device login has nothing to open. Rather than hang, the server spots them and fails straight away with guidance. Detection keys on a truthy `CI`, on `SSH_CONNECTION` or `SSH_TTY`, or, on Linux, on the absence of both `DISPLAY` and `WAYLAND_DISPLAY`. That last rule catches Linux containers as well. Only a non-Linux environment showing none of those signals slips through, and there the call waits out `HOPPSCOTCH_AUTH_TIMEOUT_MS` on a browser that never opens. `HOPPSCOTCH_FORCE_BROWSER_LOGIN=true` overrides the heuristic in the other direction.
 
 Work around it in three steps:
 

--- a/documentation/clients/mcp-server/tools.mdx
+++ b/documentation/clients/mcp-server/tools.mdx
@@ -10,7 +10,7 @@ Each table carries a **Profiles** column telling you where that tool is availabl
 
 | Profile | Tools | Notes |
 | --- | --- | --- |
-| `minimal` | 22 | Collection and environment CRUD, collection import and export, plus `reauth`. |
+| `minimal` | 22 | Collection and environment CRUD, personal collection import, team and personal collection export, plus `reauth`. |
 | `core` | 39 | The default. Adds request CRUD, request execution, code generation, `list_teams`, and `get_team_info`. |
 | `standard` | 38 | Adds team administration and advanced collection operations. **Removes** request execution, response validation, code generation, and request CRUD. |
 | `full` | 53 | Everything. |
@@ -92,8 +92,8 @@ Collections in your personal workspace. `get_user_collection` is the only one re
 | `list_user_collections` | All | List your root-level personal collections, either REST or GraphQL. |
 | `get_user_collection` | All | Get one personal collection's envelope, meaning its ID, title, parent, and data. Nested requests and child collections are not included. |
 | `create_user_collection` | All | Create a personal collection at the root or under a parent. |
-| `update_user_collection` | All | Rename a personal collection or modify its data. Targets a REST collection unless you pass `type` as `GQL`. |
-| `delete_user_collection` | All | Delete a personal collection and everything inside it. This cannot be undone. Targets a REST collection unless you pass `type` as `GQL`. |
+| `update_user_collection` | All | Rename a personal collection or modify its data. The `type` argument is accepted for compatibility but ignored; the collection ID determines the target. |
+| `delete_user_collection` | All | Delete a personal collection and everything inside it. This cannot be undone. The `type` argument is accepted for compatibility but ignored; the collection ID determines the target. |
 | `duplicate_user_collection` | `standard`, `full` | Duplicate a personal collection. Targets a REST collection unless you pass `type` as `GQL`. |
 | `move_user_collection` | `standard`, `full` | Move a personal collection under a different parent, or to the root. |
 | `import_user_collection` | All | Import personal collections from Hoppscotch export JSON. |
@@ -118,7 +118,7 @@ Individual requests stored inside a team collection.
 
 | Tool | Profiles | Description |
 | --- | --- | --- |
-| `list_team_requests` | `core`, `full` | List the requests in a team collection, with each request's full stored JSON. Returns one page per call, sized by the backend at around ten. Omit the cursor for the first page, then pass the returned cursor for the next. |
+| `list_team_requests` | `core`, `full` | List the requests in a team collection, with each request's full stored JSON. Returns one page per call, sized by the backend at around ten. Omit the cursor for the first page, then pass the last row's `id` as the cursor for the next. Nothing in the response carries a cursor field. |
 | `get_team_request` | `core`, `full` | Get one team request by ID. |
 | `create_team_request` | `core`, `full` | Create a request in a team collection. |
 | `update_team_request` | `core`, `full` | Rename a team request or modify its data. |
@@ -176,7 +176,7 @@ Sign-in control.
 - Only personal environments are read. Passing a team environment ID is rejected.
 - These tools do not inherit authentication from a parent collection. They use only the `auth` you pass in the call.
 - When you select an environment, an unresolved `{{placeholder}}` in the URL, the body, or a header value fails the call. **When you select no environment, an unresolved `{{placeholder}}` is sent rather than failing the call**, because there is nothing to resolve it against. In a URL path the braces are percent-encoded on the wire.
-- The unresolved-placeholder check covers the same three places substitution does, so two locations are outside it entirely. A placeholder in a header **name** is never substituted or checked, and the call then fails before anything is sent, because braces are not legal in a header name. A placeholder in the `auth` block is also never substituted or checked, and what reaches the wire depends on the authentication type. A bearer token is sent as written, Basic credentials are base64-encoded, an API key added to the query is percent-encoded into the URL, and an API key whose **name** is a placeholder fails the same way a placeholder header name does.
+- The unresolved-placeholder check covers the same three places substitution does, so two locations are outside it entirely. A placeholder in a header **name** is never substituted or checked, and the call then fails before anything is sent, because braces are not legal in a header name. A placeholder in the `auth` block is also never substituted or checked, and what reaches the wire depends on the authentication type. A bearer token is sent as written, Basic credentials are base64-encoded, an API key added to the query is percent-encoded into the URL, and an API key whose **name** is a placeholder fails the same way a placeholder header name does, but only in the default header placement. Added to the query instead, the name is percent-encoded and goes out as written.
 - Values marked secret substitute into a request to any origin by default. Set `HOPPSCOTCH_SECRET_ALLOWED_ORIGINS` to restrict which origins may receive them.
 
 ### What scrubbing covers

--- a/documentation/clients/mcp-server/tools.mdx
+++ b/documentation/clients/mcp-server/tools.mdx
@@ -21,19 +21,16 @@ The profile gates discovery and execution together. A tool outside your profile 
 
 ## Cloud behavior
 
-Against a self-hosted instance, Community or Enterprise, every tool works. Cloud is where it gets uneven. The personal workspace is gated there for now, but the gate lives in this server rather than the backend, and it was only ever applied to some tools. What you get therefore depends on the tool you call:
+Against a self-hosted instance, Community or Enterprise, every tool works. On Cloud, this server refuses one tool, and one other is unavailable because of a backend limitation:
 
-| On Cloud | Tools | What you see |
+| On Cloud | Tool | What you see |
 | --- | --- | --- |
-| Returns an error | `list_user_collections`, `get_user_collection`, `export_user_collection`, `list_user_requests` | A message saying the operation is not supported on Cloud, suggesting team collections instead. |
-| Returns an error | `create_user_environment`, `update_user_environment`, `delete_user_environment` | A message saying personal environments are not supported on Cloud. |
-| Returns an empty result | `list_user_environments` | An empty list. This is not an error, so an agent may read it as "you have no environments". |
-| Returns an error | `search_team_requests` | The backend rejects the query with `bug/team/no_require_team_role`, surfaced as an error. |
-| Runs normally | `create_user_collection`, `update_user_collection`, `delete_user_collection`, `import_user_collection`, `duplicate_user_collection`, `move_user_collection`, `create_user_request`, `update_user_request`, `delete_user_request`, `move_user_request` | The call succeeds. |
+| Refused by this server | `get_user_collection` | An error explaining that the backend cannot serialize the collection's `data` field, which fails the whole query. Use `list_user_collections` for root-level collections, or `export_user_collection` for a known ID. |
+| Rejected by the backend | `search_team_requests` | The backend rejects the query with `bug/team/no_require_team_role`. This comes from upstream, not from a check in this server. |
 
-<Warning>Personal collection and request **writes are not blocked on Cloud, but the matching reads are.** An agent can create a personal collection and then be unable to list it back, because `create_user_collection` runs while `list_user_collections` returns an error. Personal *environment* writes behave differently and do return an error. Use team workspaces on Cloud to avoid this entirely.</Warning>
+Those are the two tools unavailable on Cloud. No other tool carries a Cloud-specific check in this server. Apart from `get_user_collection`, the personal collection, request, and environment tools are all available there, reads included.
 
-Variable substitution is affected by the same gap. `execute_request` and `validate_response` read personal environments only, so on Cloud every `environmentId` you pass is rejected as not found. See [Request execution](#request-execution).
+`execute_request` and `validate_response` read personal environments only, so passing a team environment ID is rejected on either deployment. See [Request execution](#request-execution).
 
 ## Teams
 
@@ -88,7 +85,7 @@ Environment variables scoped to a team workspace. These work on both Cloud and s
 
 ## Personal collections
 
-Collections in your personal workspace. Read behavior differs sharply between Cloud and self-hosted. See [Cloud behavior](#cloud-behavior).
+Collections in your personal workspace. `get_user_collection` is the only one refused on Cloud. See [Cloud behavior](#cloud-behavior).
 
 | Tool | Profiles | Description |
 | --- | --- | --- |
@@ -104,7 +101,7 @@ Collections in your personal workspace. Read behavior differs sharply between Cl
 
 ## Personal environments
 
-Environment variables scoped to your personal workspace. Not supported on Cloud. See [Cloud behavior](#cloud-behavior).
+Environment variables scoped to your personal workspace. These work on Cloud and self-hosted alike.
 
 | Tool | Profiles | Description |
 | --- | --- | --- |
@@ -130,7 +127,7 @@ Individual requests stored inside a team collection.
 
 ## Personal requests
 
-Individual requests stored inside a personal collection. See [Cloud behavior](#cloud-behavior).
+Individual requests stored inside a personal collection. These work on Cloud and self-hosted alike.
 
 | Tool | Profiles | Description |
 | --- | --- | --- |
@@ -176,7 +173,7 @@ Sign-in control.
 
 - Substitution applies to the URL, header **values**, and the body. It does **not** apply to the `auth` block or to header names.
 - The `auth` block handles bearer, basic, and API key authentication. For anything else, set the `Authorization` header yourself as a normal header.
-- Only personal environments are read. Passing a team environment ID is rejected. On Cloud, personal environments are unavailable, so **any** `environmentId` is rejected.
+- Only personal environments are read. Passing a team environment ID is rejected.
 - These tools do not inherit authentication from a parent collection. They use only the `auth` you pass in the call.
 - When you select an environment, an unresolved `{{placeholder}}` in the URL, the body, or a header value fails the call. **When you select no environment, an unresolved `{{placeholder}}` is sent rather than failing the call**, because there is nothing to resolve it against. In a URL path the braces are percent-encoded on the wire.
 - The unresolved-placeholder check covers the same three places substitution does, so two locations are outside it entirely. A placeholder in a header **name** is never substituted or checked, and the call then fails before anything is sent, because braces are not legal in a header name. A placeholder in the `auth` block is also never substituted or checked, and what reaches the wire depends on the authentication type. A bearer token is sent as written, Basic credentials are base64-encoded, an API key added to the query is percent-encoded into the URL, and an API key whose **name** is a placeholder fails the same way a placeholder header name does.

--- a/documentation/clients/mcp-server/tools.mdx
+++ b/documentation/clients/mcp-server/tools.mdx
@@ -1,0 +1,217 @@
+---
+sidebarTitle: Tools
+title: Hoppscotch MCP Server Tools
+description: Reference for all 53 Hoppscotch MCP server tools, the profile that includes each one, and how they behave on Cloud and self-hosted instances.
+---
+
+All 53 tools are listed here. How many your host actually sees comes down to `HOPPSCOTCH_TOOL_PROFILE`, which defaults to `core` and exposes 39 of them.
+
+Each table carries a **Profiles** column telling you where that tool is available, and "All" means every profile, `minimal` included. CRUD is shorthand for the four basic operations on a resource: create, read, update, and delete.
+
+| Profile | Tools | Notes |
+| --- | --- | --- |
+| `minimal` | 22 | Collection and environment CRUD, plus `reauth`. |
+| `core` | 39 | The default. Adds request CRUD, request execution, code generation, `list_teams`, and `get_team_info`. |
+| `standard` | 38 | Adds team administration and advanced collection operations. **Removes** request execution, response validation, code generation, and request CRUD. |
+| `full` | 53 | Everything. |
+
+<Note>`core` and `standard` are separate branches of `full`, not a ladder. Switching from `core` to `standard` **loses** `execute_request`, `validate_response`, `generate_code`, `generate_documentation`, and all eleven request CRUD tools. Choose `full` if you need both sides.</Note>
+
+The profile gates discovery and execution together. A tool outside your profile is invisible to the host and refused even if an agent names it directly.
+
+## Cloud behavior
+
+Against a self-hosted instance, Community or Enterprise, every tool works. Cloud is where it gets uneven. The personal workspace is gated there for now, but the gate lives in this server rather than the backend, and it was only ever applied to some tools. What you get therefore depends on the tool you call:
+
+| On Cloud | Tools | What you see |
+| --- | --- | --- |
+| Returns an error | `list_user_collections`, `get_user_collection`, `export_user_collection`, `list_user_requests` | A message saying the operation is not supported on Cloud, suggesting team collections instead. |
+| Returns an error | `create_user_environment`, `update_user_environment`, `delete_user_environment` | A message saying personal environments are not supported on Cloud. |
+| Returns an empty result | `list_user_environments` | An empty list. This is not an error, so an agent may read it as "you have no environments". |
+| Returns an error | `search_team_requests` | The backend rejects the query with `bug/team/no_require_team_role`, surfaced as an error. |
+| Runs normally | `create_user_collection`, `update_user_collection`, `delete_user_collection`, `import_user_collection`, `duplicate_user_collection`, `move_user_collection`, `create_user_request`, `update_user_request`, `delete_user_request`, `move_user_request` | The call succeeds. |
+
+<Warning>Personal collection and request **writes are not blocked on Cloud, but the matching reads are.** An agent can create a personal collection and then be unable to list it back, because `create_user_collection` runs while `list_user_collections` returns an error. Personal *environment* writes behave differently and do return an error. Use team workspaces on Cloud to avoid this entirely.</Warning>
+
+Variable substitution is affected by the same gap. `execute_request` and `validate_response` read personal environments only, so on Cloud every `environmentId` you pass is rejected as not found. See [Request execution](#request-execution).
+
+## Teams
+
+Team discovery and administration. `list_teams` and `get_team_info` are read-only and ship in `core`. Every other tool here is team administration and requires `standard` or `full`.
+
+<Warning>Both read-only tools return each member's user ID, display name, and **email address** along with their role. `list_teams` does this for every team you belong to, and it is in the default profile, so asking an agent to list your teams sends your colleagues' email addresses into the model's context.</Warning>
+
+<Note>`remove_team_member` and `update_team_member_role` identify a member by **user ID**, while `invite_team_member` uses an **email address**. Read the user ID from `get_team_info` first. Removing or demoting a team's only owner is refused before the call is sent, though that check is a convenience: the backend is authoritative, and if membership cannot be read the call proceeds and the backend rejects it.</Note>
+
+| Tool | Profiles | Description |
+| --- | --- | --- |
+| `list_teams` | `core`, `standard`, `full` | List the teams you belong to, with each team's members. |
+| `get_team_info` | `core`, `standard`, `full` | Get one team's details, with its members. |
+| `create_team` | `standard`, `full` | Create a team. |
+| `rename_team` | `standard`, `full` | Rename a team. |
+| `delete_team` | `standard`, `full` | Delete a team. This cannot be undone. |
+| `leave_team` | `standard`, `full` | Leave a team you are a member of. |
+| `invite_team_member` | `standard`, `full` | Invite someone to a team by email address. Accepts `OWNER` with no extra confirmation. |
+| `revoke_team_invitation` | `standard`, `full` | Revoke a pending invitation. |
+| `remove_team_member` | `standard`, `full` | Remove a member from a team. Takes a user ID, not an email address. |
+| `update_team_member_role` | `standard`, `full` | Change a member's role to `OWNER`, `EDITOR`, or `VIEWER`. Takes a user ID, not an email address. |
+
+## Team collections
+
+Collections inside a team workspace. These work on both Cloud and self-hosted, except `search_team_requests`.
+
+| Tool | Profiles | Description |
+| --- | --- | --- |
+| `list_team_collections` | All | List a team's root-level collections. Pagination is cursor-based, with no per-call limit. |
+| `get_team_collection` | All | Get a team collection and its direct children. The backend returns about 10 children per response, so a larger collection is truncated. |
+| `create_team_collection` | All | Create a team collection at the root or under a parent. |
+| `update_team_collection` | All | Rename a team collection or modify its data. |
+| `delete_team_collection` | All | Delete a team collection and everything inside it. This cannot be undone. |
+| `duplicate_team_collection` | `standard`, `full` | Duplicate a team collection. |
+| `move_team_collection` | `standard`, `full` | Move a team collection under a different parent. |
+| `import_team_collection` | `standard`, `full` | Import a team collection from Hoppscotch export JSON. |
+| `export_team_collection` | All | Export a team collection as a full JSON tree. **Omitting the collection ID exports the entire team workspace** into the conversation, so check the size first. |
+| `search_team_requests` | `standard`, `full` | Search a team's requests by title. Returns each match's ID and title with its parent collection, not the full request JSON, and only the first page of around ten matches, with no cursor to page further. |
+
+## Team environments
+
+Environment variables scoped to a team workspace. These work on both Cloud and self-hosted.
+
+| Tool | Profiles | Description |
+| --- | --- | --- |
+| `list_team_environments` | All | List a team's environments. Values marked secret are masked. |
+| `create_team_environment` | All | Create a team environment with variables. |
+| `update_team_environment` | All | Rename a team environment or replace its variables. Supplying variables replaces the whole list rather than merging. Without `HOPPSCOTCH_DEFAULT_TEAM_ID`, you must pass both the name and the complete list. |
+| `delete_team_environment` | All | Delete a team environment. This cannot be undone. |
+
+<Note>Reading an environment masks every secret value as `<secret hidden>`, and an update **replaces the entire variable list**. Listing an environment and submitting it back would therefore write the mask over the real secret, so the server refuses that write. To keep a secret unchanged, omit that variable from the update. To change it, pass the real new value.</Note>
+
+## Personal collections
+
+Collections in your personal workspace. Read behavior differs sharply between Cloud and self-hosted. See [Cloud behavior](#cloud-behavior).
+
+| Tool | Profiles | Description |
+| --- | --- | --- |
+| `list_user_collections` | All | List your root-level personal collections, either REST or GraphQL. |
+| `get_user_collection` | All | Get one personal collection's envelope, meaning its ID, title, parent, and data. Nested requests and child collections are not included. |
+| `create_user_collection` | All | Create a personal collection at the root or under a parent. |
+| `update_user_collection` | All | Rename a personal collection or modify its data. |
+| `delete_user_collection` | All | Delete a personal collection and everything inside it. This cannot be undone. |
+| `duplicate_user_collection` | `standard`, `full` | Duplicate a personal collection. |
+| `move_user_collection` | `standard`, `full` | Move a personal collection under a different parent, or to the root. |
+| `import_user_collection` | All | Import personal collections from Hoppscotch export JSON. |
+| `export_user_collection` | All | Export one personal collection, or all of a given type, as JSON. |
+
+## Personal environments
+
+Environment variables scoped to your personal workspace. Not supported on Cloud. See [Cloud behavior](#cloud-behavior).
+
+| Tool | Profiles | Description |
+| --- | --- | --- |
+| `list_user_environments` | All | List your personal environments. Values marked secret are masked. |
+| `create_user_environment` | All | Create a personal environment with variables. |
+| `update_user_environment` | All | Rename a personal environment or replace its variables. Supplying variables replaces the whole list rather than merging. |
+| `delete_user_environment` | All | Delete a personal environment. This cannot be undone. |
+
+## Team requests
+
+Individual requests stored inside a team collection.
+
+<Warning>The read tools here return each request's **full stored JSON**, including any headers, body, and authentication saved with it. Unlike environment listings, request reads are **not** redacted, so a credential stored in a saved request reaches the model exactly as stored.</Warning>
+
+| Tool | Profiles | Description |
+| --- | --- | --- |
+| `list_team_requests` | `core`, `full` | List the requests in a team collection, with each request's full stored JSON. Returns one page per call, sized by the backend at around ten. Omit the cursor for the first page, then pass the returned cursor for the next. |
+| `get_team_request` | `core`, `full` | Get one team request by ID. |
+| `create_team_request` | `core`, `full` | Create a request in a team collection. |
+| `update_team_request` | `core`, `full` | Rename a team request or modify its data. |
+| `delete_team_request` | `core`, `full` | Delete a team request. This cannot be undone. |
+| `move_team_request` | `core`, `full` | Move a team request into a different collection. |
+
+## Personal requests
+
+Individual requests stored inside a personal collection. See [Cloud behavior](#cloud-behavior).
+
+| Tool | Profiles | Description |
+| --- | --- | --- |
+| `list_user_requests` | `core`, `full` | List the requests in a personal collection. |
+| `create_user_request` | `core`, `full` | Create a personal request, either REST or GraphQL. |
+| `update_user_request` | `core`, `full` | Rename a personal request or modify its data. |
+| `delete_user_request` | `core`, `full` | Delete a personal request. This cannot be undone. |
+| `move_user_request` | `core`, `full` | Move a personal request into a different collection. |
+
+## Request execution
+
+The tools that send real HTTP traffic. Both refuse targets on your own machine or a private network, and both cap the response body, as described in [Overview](/documentation/clients/mcp-server/overview#security). The 30 second timeout is a default that a call can override with its own `timeout` argument, between 1,000 and 120,000 milliseconds.
+
+| Tool | Profiles | Description |
+| --- | --- | --- |
+| `execute_request` | `core`, `full` | Send an HTTP request and return the response. Takes a raw method and URL, not a stored request ID. |
+| `validate_response` | `core`, `full` | Send a request and check the response against criteria such as status, headers, body, and response time. |
+
+<Warning>`validate_response` does **not** validate against a JSON Schema. The `jsonSchema` field is a deprecated alias of `jsonObject`, and both perform the same check: whether the body parses as a JSON object or array. Passing a schema document does not compare the response to it, and no error tells you the schema was ignored. Use `jsonObject: true` for the check that actually happens.</Warning>
+
+## Code generation
+
+Turn a request definition into code or documentation.
+
+| Tool | Profiles | Description |
+| --- | --- | --- |
+| `generate_code` | `core`, `full` | Generate a snippet in curl, JavaScript, Python, Go, or Rust. Credentials are live unless you pass `redactCredentials: true`. |
+| `generate_documentation` | `core`, `full` | Generate Markdown API documentation. Pass `includeExamples: true` to add code examples. Credentials are masked unless you pass `redactCredentials: false`. |
+
+<Warning>Credential masking is **best-effort, not a guarantee.** It covers the structured `auth` object, credential-looking header names and query parameters, and JSON or form-encoded body fields. An XML, plain-text, multipart, or binary body is left untouched, and a credential in an unrecognized field is not masked. Read the output before sharing it, even with masking enabled.</Warning>
+
+## Session
+
+Sign-in control.
+
+| Tool | Profiles | Description |
+| --- | --- | --- |
+| `reauth` | All | Discard the cached token and start a fresh browser sign-in. Use it to switch accounts or recover a bad session. With `HOPPSCOTCH_ACCESS_TOKEN` set it cannot change the token in use, because that token is always used as-is, but it still clears the cached session in `~/.config/hoppscotch-mcp/auth.json`. |
+
+## Variable substitution
+
+`execute_request` and `validate_response` substitute `{{variable}}` references from your personal environments. The behavior has several edges.
+
+- Substitution applies to the URL, header **values**, and the body. It does **not** apply to the `auth` block or to header names.
+- The `auth` block handles bearer, basic, and API key authentication. For anything else, set the `Authorization` header yourself as a normal header.
+- Only personal environments are read. Passing a team environment ID is rejected. On Cloud, personal environments are unavailable, so **any** `environmentId` is rejected.
+- These tools do not inherit authentication from a parent collection. They use only the `auth` you pass in the call.
+- When you select an environment, an unresolved `{{placeholder}}` in the URL, the body, or a header value fails the call. **When you select no environment, an unresolved `{{placeholder}}` is sent rather than failing the call**, because there is nothing to resolve it against. In a URL path the braces are percent-encoded on the wire.
+- The unresolved-placeholder check covers the same three places substitution does, so two locations are outside it entirely. A placeholder in a header **name** is never substituted or checked, and the call then fails before anything is sent, because braces are not legal in a header name. A placeholder in the `auth` block is also never substituted or checked, and what reaches the wire depends on the authentication type. A bearer token is sent as written, Basic credentials are base64-encoded, an API key added to the query is percent-encoded into the URL, and an API key whose **name** is a placeholder fails the same way a placeholder header name does.
+- Values marked secret substitute into a request to any origin by default. Set `HOPPSCOTCH_SECRET_ALLOWED_ORIGINS` to restrict which origins may receive them.
+
+### What scrubbing covers
+
+Secrets that a request substituted are scrubbed from the response body, headers, and error text before the model sees them. The scrubber works by matching the forms a secret takes when it is sent: the raw value, its JSON-escaped form, and the percent-encoded forms a URL produces for it. It does not match base64 or any other re-encoding.
+
+Matching on forms is what makes this best-effort. Either end of the request can produce something the forms miss:
+
+- **Your request can drop part of the value.** Everything after a `#` becomes a URL fragment and never leaves your machine, so the target only ever receives the part before it. When it echoes that prefix back, nothing matches.
+- **The target can change what it received** before echoing it, by decoding a percent-escape, turning a `+` back into a space, or splitting the value at a delimiter. Again, nothing matches.
+
+Narrower still is what gets tracked at all. Only values flagged secret go into the scrub set, so a plain variable, a credential in the `auth` block, and anything typed straight into a header are never candidates. And the set is per-request: it holds the secrets that particular call substituted, not everything sitting in the environment.
+
+<Warning>**Do not rely on response scrubbing for confidentiality.** It is a safety net for values the server itself substituted, not a guarantee that no credential reaches the model. `HOPPSCOTCH_SECRET_ALLOWED_ORIGINS` does not close the gap either: it gates which origins may receive values flagged secret, and has no bearing on plain variables, `auth` block credentials, or hand-written headers.</Warning>
+
+## Annotations
+
+Every tool carries four MCP annotation hints: `readOnlyHint`, `destructiveHint`, `idempotentHint`, and `openWorldHint`. Hosts may use them to decide whether to ask you before running a tool.
+
+<Warning>These are hints for your host, not a server-side guard. The server has **no confirmation step**. A `delete_` tool or a team-membership change takes effect on the first call. Whether you get a prompt is your host's decision.</Warning>
+
+`execute_request` and `validate_response` are marked both destructive and open-world, because the target host is arbitrary and may perform any write the credentials in the request allow.
+
+The hints are derived from each tool's name prefix, which makes them coarser than they look. `update_team_member_role`, and every `rename_` and `update_` tool, carry `destructiveHint: false`. A host that prompts only on the destructive hint will not ask before a role change or before data is overwritten.
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Overview" iconType="light" icon="circle-arrow-right" href="/documentation/clients/mcp-server/overview">
+    Installation, host setup, authentication, and configuration.
+  </Card>
+  <Card title="Troubleshooting" iconType="light" icon="circle-arrow-right" href="/documentation/clients/mcp-server/troubleshooting">
+    Errors you may see, what causes them, and how to fix them.
+  </Card>
+</CardGroup>

--- a/documentation/clients/mcp-server/tools.mdx
+++ b/documentation/clients/mcp-server/tools.mdx
@@ -81,7 +81,7 @@ Environment variables scoped to a team workspace. These work on both Cloud and s
 | `update_team_environment` | All | Rename a team environment or replace its variables. Supplying variables replaces the whole list rather than merging. Without `HOPPSCOTCH_DEFAULT_TEAM_ID`, you must pass both the name and the complete list. |
 | `delete_team_environment` | All | Delete a team environment. This cannot be undone. |
 
-<Note>Reading an environment masks every secret value as `<secret hidden>`, and an update **replaces the entire variable list**. Listing an environment and submitting it back would therefore write the mask over the real secret, so the server refuses that write. To keep a secret unchanged, omit that variable from the update. To change it, pass the real new value.</Note>
+<Note>Reading an environment masks every secret value as `<secret hidden>`, and an update **replaces the entire variable list**. Listing an environment and submitting it back would therefore write the mask over the real secret, so the server refuses that write. To leave a secret alone, omit the `variables` field entirely, which keeps every variable as it is. If you send `variables` at all, it replaces the whole list, so include every variable you mean to keep and give the secret its real value.</Note>
 
 ## Personal collections
 
@@ -200,7 +200,7 @@ Every tool carries four MCP annotation hints: `readOnlyHint`, `destructiveHint`,
 
 `execute_request` and `validate_response` are marked both destructive and open-world, because the target host is arbitrary and may perform any write the credentials in the request allow.
 
-The hints are derived from each tool's name prefix, which makes them coarser than they look. Twenty-four tools are marked `destructiveHint: true`, sixteen of them in `core`. The thirteen that write without being marked destructive are every `create_`, `import_`, and `duplicate_` tool, plus `reauth` and `invite_team_member`.
+The hints come from each tool's name prefix, with a few hand-written exceptions, which makes them coarser than they look. Twenty-five tools are marked `destructiveHint: true`, seventeen of them in `core`. The twelve that write without being marked destructive are every `create_`, `import_`, and `duplicate_` tool, plus `invite_team_member`.
 
 That last one is the sharp edge. An invitation is additive in shape, so it advertises `destructiveHint: false`, yet it accepts a role of `OWNER`. A host that prompts only on the destructive hint will not ask before an ownership grant. `invite_team_member` is not in the default profile, so reaching it takes `standard` or `full`.
 

--- a/documentation/clients/mcp-server/tools.mdx
+++ b/documentation/clients/mcp-server/tools.mdx
@@ -95,9 +95,9 @@ Collections in your personal workspace. Read behavior differs sharply between Cl
 | `list_user_collections` | All | List your root-level personal collections, either REST or GraphQL. |
 | `get_user_collection` | All | Get one personal collection's envelope, meaning its ID, title, parent, and data. Nested requests and child collections are not included. |
 | `create_user_collection` | All | Create a personal collection at the root or under a parent. |
-| `update_user_collection` | All | Rename a personal collection or modify its data. |
-| `delete_user_collection` | All | Delete a personal collection and everything inside it. This cannot be undone. |
-| `duplicate_user_collection` | `standard`, `full` | Duplicate a personal collection. |
+| `update_user_collection` | All | Rename a personal collection or modify its data. Targets a REST collection unless you pass `type` as `GQL`. |
+| `delete_user_collection` | All | Delete a personal collection and everything inside it. This cannot be undone. Targets a REST collection unless you pass `type` as `GQL`. |
+| `duplicate_user_collection` | `standard`, `full` | Duplicate a personal collection. Targets a REST collection unless you pass `type` as `GQL`. |
 | `move_user_collection` | `standard`, `full` | Move a personal collection under a different parent, or to the root. |
 | `import_user_collection` | All | Import personal collections from Hoppscotch export JSON. |
 | `export_user_collection` | All | Export one personal collection, or all of a given type, as JSON. |
@@ -203,7 +203,9 @@ Every tool carries four MCP annotation hints: `readOnlyHint`, `destructiveHint`,
 
 `execute_request` and `validate_response` are marked both destructive and open-world, because the target host is arbitrary and may perform any write the credentials in the request allow.
 
-The hints are derived from each tool's name prefix, which makes them coarser than they look. `update_team_member_role`, and every `rename_` and `update_` tool, carry `destructiveHint: false`. A host that prompts only on the destructive hint will not ask before a role change or before data is overwritten.
+The hints are derived from each tool's name prefix, which makes them coarser than they look. Twenty-four tools are marked `destructiveHint: true`, sixteen of them in `core`. The thirteen that write without being marked destructive are every `create_`, `import_`, and `duplicate_` tool, plus `reauth` and `invite_team_member`.
+
+That last one is the sharp edge. An invitation is additive in shape, so it advertises `destructiveHint: false`, yet it accepts a role of `OWNER`. A host that prompts only on the destructive hint will not ask before an ownership grant. `invite_team_member` is not in the default profile, so reaching it takes `standard` or `full`.
 
 ## Next steps
 

--- a/documentation/clients/mcp-server/tools.mdx
+++ b/documentation/clients/mcp-server/tools.mdx
@@ -10,7 +10,7 @@ Each table carries a **Profiles** column telling you where that tool is availabl
 
 | Profile | Tools | Notes |
 | --- | --- | --- |
-| `minimal` | 22 | Collection and environment CRUD, plus `reauth`. |
+| `minimal` | 22 | Collection and environment CRUD, collection import and export, plus `reauth`. |
 | `core` | 39 | The default. Adds request CRUD, request execution, code generation, `list_teams`, and `get_team_info`. |
 | `standard` | 38 | Adds team administration and advanced collection operations. **Removes** request execution, response validation, code generation, and request CRUD. |
 | `full` | 53 | Everything. |

--- a/documentation/clients/mcp-server/troubleshooting.mdx
+++ b/documentation/clients/mcp-server/troubleshooting.mdx
@@ -105,21 +105,13 @@ Header names and the `auth` block sit outside both substitution and the check, a
 
 ## `ENVIRONMENT_NOT_FOUND`
 
-> **Environment `'<id>'` not found for this account. Only personal environments are available here (team environments and Cloud user environments are not).**
+> **Environment `'<id>'` not found for this account. Only personal environments are available here; team environments are not.**
 
 `execute_request` and `validate_response` read personal environments only.
 
-### Case I
-
-**Reason:** You passed a team environment ID. Team environments are not readable by these tools on any backend.
+**Reason:** The ID is not one of the signed-in account's personal environments. It may name a team environment, belong to another account, or not exist at all.
 
 **Fix:** Pass a personal environment ID, or put the values directly in the request.
-
-### Case II
-
-**Reason:** You are on Hoppscotch Cloud. Personal environments are gated there for now, so the lookup list is always empty and **every** `environmentId` produces this error.
-
-**Fix:** Pass no `environmentId` and put the values directly in the request, or use a self-hosted instance.
 
 ## `AUTH_PAT_INVALID`
 
@@ -174,7 +166,9 @@ Several terse backend codes get translated into a fuller sentence, with the orig
 | `auth/fail` | Authentication failed or the session expired. Run the `reauth` tool (or retry to trigger sign-in) and try again. |
 | `bug/team/no_require_team_role` | This operation is unavailable on this backend (the required team-role guard is not configured server-side). Known Cloud limitation for `search_team_requests`. |
 | `team_invite/member_has_invite` | That user already has a pending invitation to this team. |
-| `email/failed` | The invitation could not be sent — the email is not a registered Hoppscotch account (Cloud requires invitees to already have an account). |
+| `email/failed` | The invitation could not be sent — the email is not a registered Hoppscotch account (Cloud requires invitees to already have an account). See the note below. |
+
+<Note>That last message is this server's own wording for the backend's terse `email/failed`, not a diagnosis from the backend. The code itself says only that sending the invitation email failed, so treat the missing-account explanation as the likely cause rather than a confirmed one.</Note>
 
 ### Case I
 
@@ -226,19 +220,15 @@ Several terse backend codes get translated into a fuller sentence, with the orig
 
 **Fix:** Run the `reauth` tool to adopt the new identity, or restart the server.
 
-## Not supported on Hoppscotch Cloud
+## `get_user_collection` on Hoppscotch Cloud
 
-> **`"<operation>"` is not supported on Hoppscotch Cloud as of now. Use team collections instead, or switch to a self-hosted instance.**
+> **`"get_user_collection"` does not work on Hoppscotch Cloud as of now: the backend fails to serialize the collection's `data` field, which errors the whole query. This is server-side, so the tool is expected to start working without an update here. Use `"list_user_collections"` meanwhile, which returns the same collections on Cloud.**
 
-**Reason:** This server gates the personal workspace on Cloud. The gate is applied client-side by the server, not returned by the backend, which is why only some tools are affected: `list_user_collections`, `get_user_collection`, `export_user_collection`, and `list_user_requests`. Personal environment writes return a comparable error.
+**Reason:** The check was added after Cloud's `userCollection` resolver failed to serialize the `data` field, which fails the whole query. The server refuses the call up front rather than handing back a broken response.
 
-`list_user_requests` uses a different second sentence, recommending team requests rather than team collections:
+**Fix:** For root-level collections, use `list_user_collections`. For a known collection ID, including a nested one, use `export_user_collection`, which works on Cloud but returns export JSON rather than the collection envelope.
 
-> **`"list_user_requests"` is not supported on Hoppscotch Cloud as of now. Use team requests instead, or switch to a self-hosted instance.**
-
-**Fix:** Use team collections and team environments on Cloud, or run a self-hosted instance.
-
-Personal collection and request writes are not gated, so `create_user_collection` succeeds while `list_user_collections` returns this error. An agent can create something it cannot then read back. See [Cloud behavior](/documentation/clients/mcp-server/tools#cloud-behavior) for the per-tool detail.
+<Note>The sentence "the tool is expected to start working without an update here" is wrong for this release. The server rejects every Cloud call before it queries the backend, so a backend fix alone cannot make the tool work. A later MCP server release has to remove the check.</Note>
 
 ## `bug/team/no_require_team_role`
 

--- a/documentation/clients/mcp-server/troubleshooting.mdx
+++ b/documentation/clients/mcp-server/troubleshooting.mdx
@@ -145,7 +145,7 @@ Header names and the `auth` block sit outside both substitution and the check, a
 
 **Reason:** Reading an environment masks every secret value as `<secret hidden>`. Supplying variables on an update replaces the whole list, so an agent that lists an environment and submits it back would write the mask over the real secret. The server refuses instead of overwriting.
 
-**Fix:** Omit the secret variable from the update to leave it unchanged, or pass its real value to change it. Omitting the entire variables list also leaves every variable as it is.
+**Fix:** Omit the `variables` field entirely, which leaves every variable as it is. If you send `variables`, it replaces the whole list, so include every variable you mean to keep and give the secret its real value rather than the mask.
 
 ## `updateTeamEnvironment` requires both name and variables
 

--- a/documentation/clients/mcp-server/troubleshooting.mdx
+++ b/documentation/clients/mcp-server/troubleshooting.mdx
@@ -165,7 +165,7 @@ Header names and the `auth` block sit outside both substitution and the check, a
 
 ## `GRAPHQL_ERROR` and `GRAPHQL_REQUEST_ERROR`
 
-These are the general wrapper the server uses when a call to the Hoppscotch backend fails. Both arrive as a `HoppscotchError` carrying a code, and sometimes an HTTP status.
+These are the general wrappers the server uses when a call to the Hoppscotch backend fails. Both arrive as a `HoppscotchError` carrying a code, and sometimes an HTTP status.
 
 Several terse backend codes get translated into a fuller sentence, with the original code kept in parentheses, so anything you search for still contains the raw code.
 

--- a/documentation/clients/mcp-server/troubleshooting.mdx
+++ b/documentation/clients/mcp-server/troubleshooting.mdx
@@ -1,0 +1,287 @@
+---
+sidebarTitle: Troubleshooting
+title: Hoppscotch MCP Server Troubleshooting
+description: Resolve Hoppscotch MCP server errors with this reference of error codes, messages, and causes covering sign-in, request execution, and Cloud limits.
+---
+
+Below are the errors the MCP server surfaces, what causes each one, and how to resolve it. How they look depends on your host, which does the presenting, but the message text itself does not change.
+
+Some diagnostic output goes to the server's standard error stream rather than into the conversation. If an error is unclear, check your host's MCP server logs.
+
+## The server does not appear in your host
+
+**Reason:** The host could not start the server, so no tools are registered and no error reaches the conversation.
+
+**Fix:** Work through these in order.
+
+1. Confirm Node.js v22 or higher is on the `PATH` the host uses. A host launched from the desktop may not inherit your shell's `PATH`.
+2. Restart the host completely after editing its configuration. Most hosts read MCP configuration only at startup.
+3. Run `npx @hoppscotch/mcp-server` in a terminal. It should start and wait. A dependency or Node.js version problem shows up here immediately.
+4. Check the host's MCP logs. Startup failures and the configuration warnings below are written to standard error, not to the conversation.
+
+## A tool you expected is missing
+
+**Reason:** `HOPPSCOTCH_TOOL_PROFILE` selects which tools exist. The profile gates discovery and execution together, so a tool outside it is invisible to the host and refused even if an agent names it directly.
+
+### Case I
+
+**Reason:** The tool is not in your profile. The default is `core`, which excludes team administration and the advanced collection operations. Switching to `standard` removes request execution, code generation, and request CRUD instead.
+
+A call to a tool outside your profile is refused with the literal message `Unknown tool: <name>`, which is the same message a tool that does not exist would produce. The message does not tell you which of the two happened.
+
+**Fix:** Check [Tools](/documentation/clients/mcp-server/tools) for which profiles include the tool, then set `HOPPSCOTCH_TOOL_PROFILE` accordingly. Use `full` if you need tools from both `core` and `standard`.
+
+### Case II
+
+**Reason:** `HOPPSCOTCH_TOOL_PROFILE` is set to a value the server does not recognize. It falls back to `core` and writes a warning to its error output.
+
+**Fix:** Check the spelling against `minimal`, `core`, `standard`, and `full`. The warning naming the bad value is in your host's MCP logs.
+
+## `SSRFBlockedError`
+
+The target of `execute_request` or `validate_response` was refused before any connection was made.
+
+### Case I
+
+> **Blocked request to a private/internal address (`<target>`). execute_request refuses loopback, link-local, cloud-metadata, and private network targets by default. Set HOPPSCOTCH_ALLOW_PRIVATE_HOSTS=true to allow them (e.g. testing a self-hosted or local API).**
+
+**Reason:** The URL resolved to an address the guard blocks. This covers loopback, private networks, link-local, carrier-grade NAT, cloud-metadata endpoints such as `169.254.169.254`, and other special-use ranges, across IPv4 and IPv6.
+
+**Fix:** If you are deliberately testing a local or self-hosted API, set `HOPPSCOTCH_ALLOW_PRIVATE_HOSTS=true` in your host's `env` block.
+
+<Warning>Setting `HOPPSCOTCH_ALLOW_PRIVATE_HOSTS=true` skips the address checks for **every** `execute_request` and `validate_response` call, not just the one you intended. An agent acting on untrusted input can then reach your internal network and return what it finds into the conversation. Enable it only when you control the input. The restriction to `http` and `https` still applies, and login and backend traffic are unaffected.</Warning>
+
+### Case II
+
+> **Could not resolve `'<host>'` to verify it is not an internal address — blocking. Retry if this is a transient DNS error, or set HOPPSCOTCH_ALLOW_PRIVATE_HOSTS=true for intentional local targets.**
+
+**Reason:** Name resolution failed, so the guard could not confirm the address is external. It fails closed, meaning it blocks rather than allowing an unverified target.
+
+**Fix:** Check the hostname for typos and confirm the machine can resolve it. Retry if the failure was transient. For a hostname that only resolves on your private network, set `HOPPSCOTCH_ALLOW_PRIVATE_HOSTS=true`.
+
+### Case III
+
+> **Unsupported URL scheme `'<protocol>'` — only http/https are allowed.**
+
+**Reason:** The URL used a scheme other than `http` or `https`, such as `file:` or `ftp:`.
+
+**Fix:** Supply an `http` or `https` URL.
+
+## `SecretEgressBlockedError`
+
+You set `HOPPSCOTCH_SECRET_ALLOWED_ORIGINS`, and a request referencing a secret environment value targeted an origin that is not on the list. The request was not sent.
+
+<Note>This error only occurs when `HOPPSCOTCH_SECRET_ALLOWED_ORIGINS` is set. Leaving it unset means no restriction, and secrets substitute into a request to any origin.</Note>
+
+<Warning>Each entry must be an absolute origin such as `https://api.example.com`. An entry that does not parse as one, such as a bare `api.example.com`, is **discarded without any warning**. If every entry is discarded the list ends up empty, which refuses secrets to all origins rather than allowing them. Setting the variable to an empty value has the same effect and is the supported way to deny all.</Warning>
+
+### Case I
+
+> **Refusing to substitute secret environment variable(s) {`<keys>`} into a request to `<origin>`: that origin is not allowlisted for secrets. Add it to HOPPSCOTCH_SECRET_ALLOWED_ORIGINS (comma-separated origins).**
+
+**Reason:** The target origin was checked before substitution and is not allowlisted.
+
+**Fix:** Add the origin to `HOPPSCOTCH_SECRET_ALLOWED_ORIGINS` if it should receive secrets. Otherwise remove the secret reference from the request.
+
+### Case II
+
+> **Refusing to send secret environment variable(s) {`<keys>`}: after substitution the request targets `<origin>`, which is not allowlisted for secrets. Check HOPPSCOTCH_SECRET_ALLOWED_ORIGINS.**
+
+**Reason:** The URL itself contained a variable, so the final origin was only known after substitution, and that origin is not allowlisted. This second check catches a request whose destination is decided by a variable.
+
+**Fix:** Confirm the variable resolves to the origin you expect, then add that origin to the allowlist if it should receive secrets.
+
+## `UnresolvedPlaceholderError`
+
+> **Unresolved variable placeholder(s): `{{name}}`. Provide them via the selected environment or remove them; the request was not sent.**
+
+**Reason:** You selected an environment, and the request still contained a `{{variable}}` that the environment does not define. The server checks the URL, the header values, and the body.
+
+**Fix:** Add the variable to the selected environment, correct the spelling, or remove the reference.
+
+<Warning>This check runs **only when you select an environment**, and only on the URL, the body, and header **values**. With no `environmentId`, an unresolved `{{variable}}` is not an error and goes out on the wire. Select an environment if you want unresolved variables to fail instead.</Warning>
+
+Header names and the `auth` block sit outside both substitution and the check, and they fail differently. Braces are not legal in a header name, so a placeholder there kills the call before anything is sent. In the `auth` block it depends on the type: a bearer token goes out as written, Basic credentials are base64-encoded first, an API key added to the query is percent-encoded into the URL, and an API key whose *name* is a placeholder fails just like a placeholder header name. Keep variables in header values or the request body if you want them resolved.
+
+## `ENVIRONMENT_NOT_FOUND`
+
+> **Environment `'<id>'` not found for this account. Only personal environments are available here (team environments and Cloud user environments are not).**
+
+`execute_request` and `validate_response` read personal environments only.
+
+### Case I
+
+**Reason:** You passed a team environment ID. Team environments are not readable by these tools on any backend.
+
+**Fix:** Pass a personal environment ID, or put the values directly in the request.
+
+### Case II
+
+**Reason:** You are on Hoppscotch Cloud. Personal environments are gated there for now, so the lookup list is always empty and **every** `environmentId` produces this error.
+
+**Fix:** Pass no `environmentId` and put the values directly in the request, or use a self-hosted instance.
+
+## `AUTH_PAT_INVALID`
+
+> **Authentication failed. The configured access token looks like a Personal Access Token (pat-...), which only works with Hoppscotch REST API endpoints, not GraphQL queries. Use device-login instead (unset the token), or copy the JWT from `~/.config/hoppscotch-mcp/auth.json`.**
+
+**Reason:** `HOPPSCOTCH_ACCESS_TOKEN` was set to a Hoppscotch personal access token. This server talks to the GraphQL API, which personal access tokens cannot authenticate against.
+
+**Fix:** Unset `HOPPSCOTCH_ACCESS_TOKEN` and use browser device login, or set it to a JWT copied from the `accessToken` field of `~/.config/hoppscotch-mcp/auth.json`.
+
+<Note>The server does **not** refuse a `pat-` token up front. It writes a warning to its error output once, then uses the token anyway. This error appears only **after** a request has already been sent and the backend rejected it. Most hosts do not surface that stderr warning, so the first visible sign is usually a failed tool call.</Note>
+
+## `MISSING_TEAM_ID`
+
+> **Team ID is required. Either provide teamId parameter or set HOPPSCOTCH_DEFAULT_TEAM_ID**
+
+**Reason:** A team-scoped tool was called without a team ID, and no default is configured.
+
+**Fix:** Set `HOPPSCOTCH_DEFAULT_TEAM_ID` in your host's `env` block, or ask the agent to call `list_teams` first and pass the ID explicitly.
+
+## `COLLECTION_NOT_FOUND`
+
+> **User collection `"<id>"` not found or not accessible.**
+
+**Reason:** The collection ID does not exist, or it belongs to an account other than the signed-in one.
+
+**Fix:** Confirm the ID and the signed-in account. Use `reauth` to switch accounts.
+
+## Refusing to write the secret-redaction placeholder
+
+> **Refusing to write the secret-redaction placeholder ("`<secret hidden>`") as the value of variable "`<key>`". This placeholder is what a secret variable shows when read back; writing it would overwrite the real secret. To leave a secret unchanged, omit that variable (or the entire variables list) from the update; to change it, pass the new real value.**
+
+**Reason:** Reading an environment masks every secret value as `<secret hidden>`. Supplying variables on an update replaces the whole list, so an agent that lists an environment and submits it back would write the mask over the real secret. The server refuses instead of overwriting.
+
+**Fix:** Omit the secret variable from the update to leave it unchanged, or pass its real value to change it. Omitting the entire variables list also leaves every variable as it is.
+
+## `updateTeamEnvironment` requires both name and variables
+
+> **updateTeamEnvironment requires both name and variables when HOPPSCOTCH_DEFAULT_TEAM_ID is not configured. Either pass both fields, or set HOPPSCOTCH_DEFAULT_TEAM_ID so the server can look up the current values.**
+
+**Reason:** A partial update needs the current values, and the tool takes no team ID with which to look them up.
+
+**Fix:** Pass both `name` and the complete variables list, or set `HOPPSCOTCH_DEFAULT_TEAM_ID` so the server can read the current values itself.
+
+## `GRAPHQL_ERROR` and `GRAPHQL_REQUEST_ERROR`
+
+These are the general wrapper the server uses when a call to the Hoppscotch backend fails. Both arrive as a `HoppscotchError` carrying a code, and sometimes an HTTP status.
+
+Several terse backend codes get translated into a fuller sentence, with the original code kept in parentheses, so anything you search for still contains the raw code.
+
+| Backend code | Message you see |
+| --- | --- |
+| `auth/fail` | Authentication failed or the session expired. Run the `reauth` tool (or retry to trigger sign-in) and try again. |
+| `bug/team/no_require_team_role` | This operation is unavailable on this backend (the required team-role guard is not configured server-side). Known Cloud limitation for `search_team_requests`. |
+| `team_invite/member_has_invite` | That user already has a pending invitation to this team. |
+| `email/failed` | The invitation could not be sent — the email is not a registered Hoppscotch account (Cloud requires invitees to already have an account). |
+
+### Case I
+
+> **GraphQL error: Authentication failed or the session expired. Run the `reauth` tool (or retry to trigger sign-in) and try again. (auth/fail)**
+
+**Reason:** Code `GRAPHQL_ERROR`. The session is no longer accepted by the backend.
+
+**Fix:** The server already clears the stored token and retries once, so a transient expiry usually resolves itself. If the error persists, run the `reauth` tool. Deleting `~/.config/hoppscotch-mcp/auth.json` is a fallback, not the first step.
+
+### Case II
+
+> **GraphQL error: `<messages>`**
+
+**Reason:** Code `GRAPHQL_ERROR`. The backend accepted the request and returned some other error, typically a permission problem or a rejected argument.
+
+**Fix:** Read the embedded message. Check that the signed-in account has the required role on the team or resource.
+
+### Case III
+
+> **GraphQL request failed (HTTP `<status>`)**
+
+**Reason:** Code `GRAPHQL_REQUEST_ERROR`. The HTTP call itself failed. Only the status is reported, because the underlying error text embeds the query and variables and is deliberately not surfaced.
+
+**Fix:** A `401` means the session is no longer valid, so run `reauth`. A `5xx` points at the backend. For a self-hosted instance, confirm `HOPPSCOTCH_SERVER_URL` is the frontend URL and that `/backend` is routed correctly.
+
+### Case IV
+
+> **GraphQL request failed: `<message>`**
+
+**Reason:** Code `GRAPHQL_REQUEST_ERROR` from a network, DNS, or timeout failure. No response was received.
+
+**Fix:** Check connectivity to the instance and the value of `HOPPSCOTCH_SERVER_URL`.
+
+## Browser device-login is unavailable
+
+> **Browser device-login is unavailable (headless/CI/SSH environment detected). Set HOPPSCOTCH_ACCESS_TOKEN to a Hoppscotch JWT for non-interactive auth, or set HOPPSCOTCH_FORCE_BROWSER_LOGIN=true if a browser is actually available here.**
+
+**Reason:** The server detected a continuous integration runner, an SSH session, or a machine with no display. Device login cannot complete there, so it fails immediately instead of hanging for five minutes.
+
+**Fix:** Complete a device login once on a machine with a browser, copy the `accessToken` value from `~/.config/hoppscotch-mcp/auth.json`, and set it as `HOPPSCOTCH_ACCESS_TOKEN` in the headless environment. If a browser really is available and detection got it wrong, set `HOPPSCOTCH_FORCE_BROWSER_LOGIN=true`.
+
+<Warning>A token set through `HOPPSCOTCH_ACCESS_TOKEN` is never refreshed and keeps the expiry it was issued with, about an hour on Cloud and about a day on self-hosted. A headless setup needs external rotation, not a one-time copy.</Warning>
+
+## Signed-in account changed
+
+> **Signed-in account changed: the token stored at `~/.config/hoppscotch-mcp/auth.json` belongs to a different account than this session authenticated as. Run the `reauth` tool to switch accounts.**
+
+**Reason:** The session is one identity per operating-system user, shared by every MCP host process. Another process signed in as a different account while this server was running. Rather than silently acting as the wrong account, the server refuses.
+
+**Fix:** Run the `reauth` tool to adopt the new identity, or restart the server.
+
+## Not supported on Hoppscotch Cloud
+
+> **`"<operation>"` is not supported on Hoppscotch Cloud as of now. Use team collections instead, or switch to a self-hosted instance.**
+
+**Reason:** This server gates the personal workspace on Cloud. The gate is applied client-side by the server, not returned by the backend, which is why only some tools are affected: `list_user_collections`, `get_user_collection`, `export_user_collection`, and `list_user_requests`. Personal environment writes return a comparable error.
+
+`list_user_requests` uses a different second sentence, recommending team requests rather than team collections:
+
+> **`"list_user_requests"` is not supported on Hoppscotch Cloud as of now. Use team requests instead, or switch to a self-hosted instance.**
+
+**Fix:** Use team collections and team environments on Cloud, or run a self-hosted instance.
+
+Personal collection and request writes are not gated, so `create_user_collection` succeeds while `list_user_collections` returns this error. An agent can create something it cannot then read back. See [Cloud behavior](/documentation/clients/mcp-server/tools#cloud-behavior) for the per-tool detail.
+
+## `bug/team/no_require_team_role`
+
+> **This operation is unavailable on this backend (the required team-role guard is not configured server-side). Known Cloud limitation for `search_team_requests`.**
+
+**Reason:** `search_team_requests` is unavailable on Hoppscotch Cloud. The backend rejects the query with this code, and the server translates it into the sentence above while keeping the raw code in the text.
+
+**Fix:** Browse with `list_team_collections` and `list_team_requests` instead, or run the search against a self-hosted instance.
+
+## Response truncated
+
+> **[response truncated at HOPPSCOTCH_MAX_RESPONSE_BYTES]**
+
+**Reason:** The response body went past the buffering cap, 5,000,000 bytes by default. Rather than fail the call, the server appends this marker as a plain line of text so neither you nor the agent mistakes a partial body for a complete one. You will also see it when output was clamped during secret redaction.
+
+**Fix:** Narrow the request with filters, pagination, or a range header. Raise `HOPPSCOTCH_MAX_RESPONSE_BYTES` only if you need the whole body, keeping in mind that the entire response is returned into the model's context.
+
+## Request timed out
+
+**Reason:** The target did not respond in time. The limit is the call's own `timeout` argument when one was supplied, and `HOPPSCOTCH_TIMEOUT` otherwise, which defaults to 30,000 milliseconds.
+
+**Fix:** Confirm the endpoint is reachable. A single call can pass `timeout` between 1,000 and 120,000 milliseconds without any change to your configuration. Raise `HOPPSCOTCH_TIMEOUT` to change the default for every call.
+
+## Browser does not open
+
+**Reason:** The server could not launch a browser, though the environment was not detected as headless.
+
+**Fix:** The login URL is written to the server's error output. Copy it from your host's MCP logs and open it manually.
+
+## Login timed out
+
+**Reason:** The browser sign-in was not completed within five minutes, so the local callback closed.
+
+**Fix:** Retry the tool call and complete the sign-in within five minutes. `HOPPSCOTCH_AUTH_TIMEOUT_MS` controls only how long a single tool call waits before returning the login URL to you. It does not extend the five-minute callback window.
+
+## SSL certificate errors on self-hosted
+
+**Reason:** Your instance presents a self-signed certificate or one issued by a private certificate authority that Node.js does not trust.
+
+**Fix:** Point Node.js at your certificate authority bundle with `NODE_EXTRA_CA_CERTS=/path/to/ca.pem` in the server environment.
+
+<Warning>Do **not** set `NODE_TLS_REJECT_UNAUTHORIZED=0`. It disables certificate verification for the entire process, including Cloud token exchange and every request `execute_request` makes to public hosts, not only your self-hosted instance.</Warning>
+
+## Still stuck
+
+Report a bug by [opening a new issue](https://github.com/hoppscotch/hoppscotch-mcp-server/issues/new/choose) on the MCP server repository.

--- a/documentation/clients/mcp-server/troubleshooting.mdx
+++ b/documentation/clients/mcp-server/troubleshooting.mdx
@@ -101,7 +101,7 @@ You set `HOPPSCOTCH_SECRET_ALLOWED_ORIGINS`, and a request referencing a secret 
 
 <Warning>This check runs **only when you select an environment**, and only on the URL, the body, and header **values**. With no `environmentId`, an unresolved `{{variable}}` is not an error and goes out on the wire. Select an environment if you want unresolved variables to fail instead.</Warning>
 
-Header names and the `auth` block sit outside both substitution and the check, and they fail differently. Braces are not legal in a header name, so a placeholder there kills the call before anything is sent. In the `auth` block it depends on the type: a bearer token goes out as written, Basic credentials are base64-encoded first, an API key added to the query is percent-encoded into the URL, and an API key whose *name* is a placeholder fails just like a placeholder header name. Keep variables in header values or the request body if you want them resolved.
+Header names and the `auth` block sit outside both substitution and the check, and they fail differently. Braces are not legal in a header name, so a placeholder there kills the call before anything is sent. In the `auth` block it depends on the type: a bearer token goes out as written, Basic credentials are base64-encoded first, an API key added to the query is percent-encoded into the URL, and an API key whose *name* is a placeholder fails just like a placeholder header name, though only in the default header placement, since a query-placed key is percent-encoded and sent as written. Keep variables in header values or the request body if you want them resolved.
 
 ## `ENVIRONMENT_NOT_FOUND`
 
@@ -166,7 +166,7 @@ Several terse backend codes get translated into a fuller sentence, with the orig
 | `auth/fail` | Authentication failed or the session expired. Run the `reauth` tool (or retry to trigger sign-in) and try again. |
 | `bug/team/no_require_team_role` | This operation is unavailable on this backend (the required team-role guard is not configured server-side). Known Cloud limitation for `search_team_requests`. |
 | `team_invite/member_has_invite` | That user already has a pending invitation to this team. |
-| `email/failed` | The invitation could not be sent — the email is not a registered Hoppscotch account (Cloud requires invitees to already have an account). See the note below. |
+| `email/failed` | The invitation could not be sent — the email is not a registered Hoppscotch account (Cloud requires invitees to already have an account). |
 
 <Note>That last message is this server's own wording for the backend's terse `email/failed`, not a diagnosis from the backend. The code itself says only that sending the invitation email failed, so treat the missing-account explanation as the likely cause rather than a confirmed one.</Note>
 
@@ -176,7 +176,7 @@ Several terse backend codes get translated into a fuller sentence, with the orig
 
 **Reason:** Code `GRAPHQL_ERROR`. The session is no longer accepted by the backend.
 
-**Fix:** The server already clears the stored token and retries once, so a transient expiry usually resolves itself. If the error persists, run the `reauth` tool. Deleting `~/.config/hoppscotch-mcp/auth.json` is a fallback, not the first step.
+**Fix:** The server already clears the stored token and retries once, so a transient expiry usually resolves itself. If the error persists on a browser-login session, run the `reauth` tool; deleting `~/.config/hoppscotch-mcp/auth.json` is a fallback, not the first step. With `HOPPSCOTCH_ACCESS_TOKEN` set, `reauth` returns that same token untouched, so rotate the token or unset the variable and restart the MCP process.
 
 ### Case II
 
@@ -192,7 +192,7 @@ Several terse backend codes get translated into a fuller sentence, with the orig
 
 **Reason:** Code `GRAPHQL_REQUEST_ERROR`. The HTTP call itself failed. Only the status is reported, because the underlying error text embeds the query and variables and is deliberately not surfaced.
 
-**Fix:** A `401` means the session is no longer valid, so run `reauth`. A `5xx` points at the backend. For a self-hosted instance, confirm `HOPPSCOTCH_SERVER_URL` is the frontend URL and that `/backend` is routed correctly.
+**Fix:** A `401` means the session is no longer valid. On a browser-login session, run `reauth`. With `HOPPSCOTCH_ACCESS_TOKEN` set, `reauth` hands back the same token, so rotate it or unset the variable and restart the MCP process. A `5xx` points at the backend. For a self-hosted instance, confirm `HOPPSCOTCH_SERVER_URL` is the frontend URL and that `/backend` is routed correctly.
 
 ### Case IV
 
@@ -218,21 +218,21 @@ Several terse backend codes get translated into a fuller sentence, with the orig
 
 **Reason:** The session is one identity per operating-system user, shared by every MCP host process. Another process signed in as a different account while this server was running. Rather than silently acting as the wrong account, the server refuses.
 
-**Fix:** Run the `reauth` tool to adopt the new identity, or restart the server.
+**Fix:** On a browser-login session, run the `reauth` tool to adopt the new identity, or restart the server. With `HOPPSCOTCH_ACCESS_TOKEN` set, the identity comes from that token, so change or unset it and restart the MCP process.
 
 ## `get_user_collection` on Hoppscotch Cloud
 
-> **`"get_user_collection"` does not work on Hoppscotch Cloud as of now: the backend fails to serialize the collection's `data` field, which errors the whole query. This is server-side, so the tool is expected to start working without an update here. Use `"list_user_collections"` meanwhile, which returns the same collections on Cloud.**
+> **`"get_user_collection"` does not work on Hoppscotch Cloud as of now: the backend fails to serialize the collection's `data` field, which errors the whole query. The check lives in this server, so re-enabling it needs an update here. Use `"list_user_collections"` for root-level collections, or `"export_user_collection"` for a known ID.**
 
 **Reason:** The check was added after Cloud's `userCollection` resolver failed to serialize the `data` field, which fails the whole query. The server refuses the call up front rather than handing back a broken response.
 
 **Fix:** For root-level collections, use `list_user_collections`. For a known collection ID, including a nested one, use `export_user_collection`, which works on Cloud but returns export JSON rather than the collection envelope.
 
-<Note>The sentence "the tool is expected to start working without an update here" is wrong for this release. The server rejects every Cloud call before it queries the backend, so a backend fix alone cannot make the tool work. A later MCP server release has to remove the check.</Note>
+<Note>The refusal is enforced by this MCP server before it queries Cloud. After the backend is fixed, a later MCP server release still has to remove the check.</Note>
 
 ## `bug/team/no_require_team_role`
 
-> **This operation is unavailable on this backend (the required team-role guard is not configured server-side). Known Cloud limitation for `search_team_requests`.**
+> **GraphQL error: This operation is unavailable on this backend (the required team-role guard is not configured server-side). Known Cloud limitation for `search_team_requests`. (bug/team/no_require_team_role)**
 
 **Reason:** `search_team_requests` is unavailable on Hoppscotch Cloud. The backend rejects the query with this code, and the server translates it into the sentence above while keeping the raw code in the text.
 

--- a/documentation/features/ai-features.mdx
+++ b/documentation/features/ai-features.mdx
@@ -57,3 +57,13 @@ Develop test cases for your API workflow:
 1. Click the **Modify with AI** icon **( .⟡⁺ )** in the **Tests** section.
 2. Specify the test parameters or expected outcomes.
 3. Select **Accept Change** to integrate it into the test script editor for execution.
+
+### Connect an AI agent with the MCP server
+
+The features above run inside the Hoppscotch app. To let an external AI agent work with your collections, environments, and teams, use the Hoppscotch MCP server. It exposes those resources to hosts such as Claude Desktop, Claude Code, and Codex, and can execute HTTP requests on your behalf.
+
+<Note>The MCP server is a separate, generally available product. The experimental status and the alpha notice above apply to the in-app AI features, not to it. Unlike those features, it works with both [Hoppscotch Cloud](https://hoppscotch.io) and self-hosted instances.</Note>
+
+<Card title="Hoppscotch MCP Server" iconType="light" icon="circle-arrow-right" href="/documentation/clients/mcp-server/overview">
+  Install the server, connect your MCP host, and review what each tool can do.
+</Card>

--- a/documentation/getting-started/clients.mdx
+++ b/documentation/getting-started/clients.mdx
@@ -6,7 +6,7 @@ description: Explore the Hoppscotch clients available on web, desktop, and CLI. 
 
 import HoppscotchClients from "/snippets/hoppscotch-clients.mdx"
 
-Hoppscotch has multiple clients that you can use to develop and test your APIs. You can use Hoppscotch on the web, desktop, and terminal.
+Hoppscotch has multiple clients that you can use to develop and test your APIs. You can use Hoppscotch on the web, desktop, and terminal, or connect an AI agent to it with the MCP server.
 
 <HoppscotchClients />
 

--- a/documentation/getting-started/clients.mdx
+++ b/documentation/getting-started/clients.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Clients
 title: Hoppscotch Clients
-description: Explore the Hoppscotch clients available on web, desktop, and CLI. Learn about the user interface and how to navigate the platform.
+description: Explore the Hoppscotch clients available on web, desktop, CLI, and the MCP server for AI agents. Learn about the user interface and how to navigate the platform.
 ---
 
 import HoppscotchClients from "/snippets/hoppscotch-clients.mdx"

--- a/snippets/hoppscotch-clients.mdx
+++ b/snippets/hoppscotch-clients.mdx
@@ -1,5 +1,6 @@
-<CardGroup cols={3}>
+<CardGroup cols={2}>
   <Card title="Web" iconType="light" icon="globe" href="/documentation/clients/web/overview"></Card>
   <Card title="Desktop" iconType="light" icon="desktop" href="/documentation/clients/desktop/overview"></Card>
   <Card title="CLI" iconType="light" icon="square-terminal" href="/documentation/clients/cli/overview"></Card>
+  <Card title="MCP server" iconType="light" icon="plug" href="/documentation/clients/mcp-server/overview"></Card>
 </CardGroup>


### PR DESCRIPTION
Closes HP-376.

Documents the Hoppscotch MCP server, which exposes collections, requests, environments and teams to MCP hosts and executes HTTP requests on the user's behalf. It sits under Clients as a fourth client alongside Web, Desktop and CLI.

### What's changed

- New section, three pages following the CLI's shape. **Overview** covers install, host registration for Claude Code, Codex and Claude Desktop, the device-login flow, all twelve `HOPPSCOTCH_` variables, the four tool profiles, Cloud versus self-hosted, and security. **Tools** lists all 53 tools with the profile that includes each. **Troubleshooting** takes one section per error, keyed by the literal message.
- Navigation: a `MCP server` group in `docs.json`, a fourth card in `snippets/hoppscotch-clients.mdx` (grid moves from three columns to two), and the landing sentence plus frontmatter description in `documentation/getting-started/clients.mdx`.
- Cross-link from `documentation/features/ai-features.mdx`, which described only the in-app AI features and had no MCP mention.