### PR TITLE
Improve SEO metadata across all documentation pages

### DIFF
--- a/documentation/changelog.mdx
+++ b/documentation/changelog.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Changelog
 title: Changelog
-description: New updates and improvements to Hoppscotch.
+description: Stay up to date with the latest Hoppscotch releases, new features, bug fixes, and performance improvements across the web, desktop, and CLI clients.
 ---
 
 - Section moved to [GitHub Releases page](https://github.com/hoppscotch/hoppscotch/releases).

--- a/documentation/clients/cli/overview.mdx
+++ b/documentation/clients/cli/overview.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Overview
 title: Hoppscotch CLI
-description: Run tests, manage automated API monitoring, and more.
+description: Use the Hoppscotch CLI to run API tests, automate monitoring, and manage collections from your terminal. Includes install steps and commands.
 ---
 
 Hoppscotch gives you multiple ways to interact with and configure your APIs. With the command-line interface (CLI) you can interact with the Hoppscotch platform using a terminal, or through an automated system. This enables you to run API tests, manage automated API monitoring, and more.

--- a/documentation/clients/cli/troubleshooting.mdx
+++ b/documentation/clients/cli/troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Troubleshooting
 title: Hoppscotch CLI Troubleshooting
-description:  Troubleshoot the CLI errors by understanding their meanings and possible causes.
+description: Resolve Hoppscotch CLI errors with this reference of error codes, messages, and causes related to tokens, workspace access, and collections.
 ---
 
 Below is a set of error codes and the corresponding messages that will be displayed in the CLI under various scenarios associated with workspace access. Understanding the reasons behind these errors will help you troubleshoot them on your end.

--- a/documentation/clients/desktop.mdx
+++ b/documentation/clients/desktop.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Desktop
 title: Hoppscotch Desktop App
-description: Cross-platform desktop application that runs on macOS, Windows, and Linux.
+description: Download and install the Hoppscotch Desktop App for macOS, Windows, and Linux. Build and test APIs natively with a cross-platform client.
 ---
 
 Hoppscotch Desktop App is a cross-platform desktop application that helps you create and manage API requests. It is built on top of the [Hoppscotch Web Client](/documentation/clients/web) and is powered by [Tauri](https://tauri.app).

--- a/documentation/clients/web.mdx
+++ b/documentation/clients/web.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Web
 title: Hoppscotch Web App
-description: Build, test, and share your APIs directly in your browser.
+description: Access the Hoppscotch Web App to build, test, and share APIs directly in your browser. Also available as a progressive web app (PWA).
 ---
 
 Hoppscotch web client provides you with a really easy interface to develop and test your APIs. You can start using the web client by opening [hoppscotch.io](https://hoppscotch.io) in your browser.

--- a/documentation/community.mdx
+++ b/documentation/community.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Community
 title: Community
-description: Join our open communities and forums.
+description: Join the Hoppscotch community on Discord, GitHub, and X. Share feedback, get help from other developers, and stay updated on product releases.
 ---
 
 At Hoppscotch, we believe that the community is the most important part of our product. We want to make sure that our users have a great experience using our products and that they can contribute to the development of our products with their ideas, feedback, and suggestions.

--- a/documentation/contributors.mdx
+++ b/documentation/contributors.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Contributors
 title: Contributors
-description: Hoppscotch exists thanks to the awesome people who contribute to it.
+description: Meet the open-source contributors behind Hoppscotch. View the full list of developers who help build and improve the API platform.
 ---
 
 Hoppscotch is a community-driven project. We are thankful to all the contributors who have helped us in making Hoppscotch a better tool for developers.

--- a/documentation/develop.mdx
+++ b/documentation/develop.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Develop
 title: Develop
-description: Learn how to contribute to Hoppscotch.
+description: Contribute to Hoppscotch by reporting bugs, proposing features, or submitting pull requests. Learn the development workflow and guidelines.
 ---
 
 We love your input! We want to make contributing to Hoppscotch as easy and transparent as possible, whether it's:

--- a/documentation/features/ai-features.mdx
+++ b/documentation/features/ai-features.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: AI Features 
 title: AI Features
-description: Optimize API Development and Testing Workflows with Hoppscotch using AI.
+description: Use AI-powered features in Hoppscotch to rename requests, generate payloads, and write pre-request scripts and test cases automatically.
 ---
 
 <span style={{ 

--- a/documentation/features/authorization.mdx
+++ b/documentation/features/authorization.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Authorization
 title: Authorization
-description: Authorization is the process of verifying that a client has permission to access a resource.
+description: Configure API authorization in Hoppscotch using Basic Auth, Bearer Tokens, OAuth 2.0, and more. Set auth at the request or collection level.
 ---
 
 REST APIs use authorization to ensure that a client has secure access only to the resources permitted by their roles. If you are building or integrating with a 3rd party API, you can choose between Basic Auth, Bearer Tokens, and OAuth2.0.

--- a/documentation/features/client-certificate.mdx
+++ b/documentation/features/client-certificate.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Client Certificate
 title: Client Certificate
-description: Configure client certificates for SSL authentication in Hoppscotch.
+description: Add and manage PEM or PFX client certificates for SSL/TLS authentication in the Hoppscotch Desktop App or via the Hoppscotch Agent.
 ---
 
 Add and manage client certificates in [Hoppscotch Desktop App](https://hoppscotch.com/download) or in Hoppscotch Web App using the [Hoppscotch Agent](/documentation/features/interceptor#hoppscotch-agent) as an interceptor to authenticate your identity when connecting to secure APIs.

--- a/documentation/features/collections.mdx
+++ b/documentation/features/collections.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Collections
 title: Collections
-description: Save, organize, and share your API requests with collections.
+description: Create, organize, and share API request collections in Hoppscotch. Import and export collections from Postman, OpenAPI, and other formats.
 ---
 
 Hoppscotch helps you to organize your API requests with collections. You can create collections and add requests to them to share with your team or to use later. You can also import and export collections from Hoppscotch, OpenAPI, and Postman.

--- a/documentation/features/context-menu.mdx
+++ b/documentation/features/context-menu.mdx
@@ -1,8 +1,7 @@
 ---
 sidebarTitle: Context Menu
 title: Context Menu
-description:
-  Use context-aware menus to assist with your actions and improve your workflow.
+description: Use the Hoppscotch context menu to quickly set environment variables, add query parameters, or open requests in new tabs from selected text.
 ---
 
 Context-aware menus enable quick actions like creating variables or adding query

--- a/documentation/features/cookies.mdx
+++ b/documentation/features/cookies.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Cookies
 title: Cookies
-description: Create and modify cookies associated with a domain and send cookies with requests.
+description: Use the Hoppscotch Cookie Manager to add, edit, and remove cookies for specific domains. Send cookies with API requests in the Desktop App.
 ---
 
 <Info>Cookies support is only available in the [Hoppscotch Desktop App](/documentation/clients/desktop).</Info>

--- a/documentation/features/customization.mdx
+++ b/documentation/features/customization.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Customization
 title: Customization
-description: Customize your Hoppscotch experience.
+description: Personalize Hoppscotch by changing the background color, accent color, font size, language, and other settings to match your workflow.
 ---
 
 You can access the customization settings by clicking on the "[**Settings**](https://hoppscotch.io/settings)" icon on the side panel.

--- a/documentation/features/documentation.mdx
+++ b/documentation/features/documentation.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Documentation
 title: API Documentation
-description: Create, edit, and publish beautiful API documentation collaboratively with your team.
+description: Generate API documentation from your Hoppscotch collections with code samples, Markdown descriptions, and shareable public URLs for your team.
 ---
 
 When you build a collection in Hoppscotch, documentation is generated for you out of the box. It covers every endpoint with ready-to-use code samples across popular languages. Request information like HTTP method, URL, headers, auth configuration, payload format, and response examples are all captured automatically.

--- a/documentation/features/environments.mdx
+++ b/documentation/features/environments.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Environments
 title: Environments
-description: Environments help you create variables that you can reuse in requests and scripts.
+description: Create global, personal, and shared environments in Hoppscotch to manage reusable variables across API requests, scripts, and workspaces.
 ---
 
 An environment allows you to group together a set of variable data. You can reference the variable data you define in an environment throughout Hoppscotch when sending requests or using scripts.

--- a/documentation/features/graphql-api-testing.mdx
+++ b/documentation/features/graphql-api-testing.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: GraphQL API
 title: GraphQL API Testing
-description: Test and play around with GraphQL APIs.
+description: Test GraphQL APIs in Hoppscotch with the query builder, schema explorer, variables, headers, and real-time response inspection tools.
 ---
 
 Hoppscotch's GraphQL API platform provides you with the best experience to test and play around with GraphQL.

--- a/documentation/features/history.mdx
+++ b/documentation/features/history.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: History
 title: History
-description: Store and access your previous requests and responses.
+description: View and revisit your past API requests and responses in Hoppscotch. Favorite, filter, and quickly re-send previous requests from history.
 ---
 
 Hoppscotch helps you to keep track of your requests and responses. You can access the history of your requests by clicking on the "**History**" icon on the side panel.

--- a/documentation/features/importer.mdx
+++ b/documentation/features/importer.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Importer
 title: Importer
-description: Migrate your data from other tools into Hoppscotch.
+description: Import collections and environments from Postman, Insomnia, OpenAPI, and other tools into Hoppscotch. Supports JSON and HAR formats.
 ---
 
 Import data from other tools into Hoppscotch. You can import data from the following tools:

--- a/documentation/features/inspections.mdx
+++ b/documentation/features/inspections.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Inspections
 title: Inspections
-description: Detect and resolve configuration errors in your API requests.
+description: Use Hoppscotch inspections to detect misconfigured API request inputs like missing headers, parameters, or auth settings before sending.
 ---
 
 Hoppscotch inspections offer a powerful solution for debugging API requests, assisting in reducing errors due to misconfigured user inputs. 

--- a/documentation/features/interceptor.mdx
+++ b/documentation/features/interceptor.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Interceptor
 title: Interceptor
-description: Intercept and modify requests and responses.
+description: Bypass CORS restrictions using the Hoppscotch Agent, Proxyscotch, browser extension, or custom middleware to intercept API requests.
 ---
 
 You can access APIs blocked by `Cross-Origin Resource Sharing (CORS)` restriction by using either Hoppscotch Agent, Proxyscotch or custom middleware. You can also use the Hoppscotch web extension to intercept requests and responses.

--- a/documentation/features/mock.mdx
+++ b/documentation/features/mock.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Mock
 title: API Mocking
-description: Create mock servers to simulate API endpoints and iterate on your API design without touching a backend.
+description: Create mock servers in Hoppscotch to simulate API endpoints with custom responses, status codes, and latency for prototyping and testing.
 ---
 
 Hoppscotch API Mocking lets you stand up mock servers that return predictable responses to HTTP requests. It's ideal for prototyping, front‑end development, contract-first API design, demos, and testing failure/latency scenarios, now built right into Hoppscotch.

--- a/documentation/features/pat.mdx
+++ b/documentation/features/pat.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Personal Access Token
 title: Personal Access Token
-description: Securely connect your Hoppscotch account with other services within Hoppscotch ecosystem.
+description: Generate and manage personal access tokens (PATs) to authenticate the Hoppscotch CLI with your Hoppscotch Cloud or self-hosted instance.
 ---
 
 A Personal Access Token (PAT) in Hoppscotch acts as a secure authentication method,

--- a/documentation/features/realtime-api-testing.mdx
+++ b/documentation/features/realtime-api-testing.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Realtime API
 title: Realtime API Testing
-description: Test and interact with real-time APIs using WebSocket, SSE, Socket.IO, and MQTT.
+description: Connect to and test real-time APIs in Hoppscotch using WebSocket, Server-Sent Events (SSE), Socket.IO, and MQTT protocols with live logs.
 ---
 
 Hoppscotch's Realtime API platform helps you test your real-time APIs easily.

--- a/documentation/features/rest-api-testing.mdx
+++ b/documentation/features/rest-api-testing.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: RESTful API
 title: RESTful API Testing
-description: Test and play around with your RESTful API endpoints.
+description: Build and debug RESTful API requests in Hoppscotch with support for HTTP methods, headers, parameters, body, auth, and pre-request scripts.
 ---
 
 Hoppscotch's REST API platform provides you with a fast and seamless experience to test and debug your API endpoints.

--- a/documentation/features/runner.mdx
+++ b/documentation/features/runner.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Runner
 title: Runner
-description: Iterate and execute your requests in a collection.
+description: Run all requests in a Hoppscotch collection sequentially with configurable delays, iterations, and environment variables using the Runner.
 ---
 
 The Runner is a powerful tool that allows you to run a collection of requests sequentially. You can also configure the run settings to suit your needs.

--- a/documentation/features/scripts.mdx
+++ b/documentation/features/scripts.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Scripts
 title: Scripts
-description: Write pre-request scripts and build tests.
+description: Write pre-request scripts and post-request tests in Hoppscotch using JavaScript to add dynamic behavior, set variables, and validate responses.
 ---
 
 <Tabs>

--- a/documentation/features/shortcuts.mdx
+++ b/documentation/features/shortcuts.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Shortcuts
 title: Shortcuts
-description: Keyboard shortcuts for Hoppscotch.
+description: Browse the full list of keyboard shortcuts in Hoppscotch for sending requests, navigating tabs, managing collections, and switching views.
 ---
 
 You can improve your workflow by efficiently performing actions straight from your keyboard.

--- a/documentation/features/snippets.mdx
+++ b/documentation/features/snippets.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Code Snippets
 title: Code Snippets
-description: Generate code snippets for your API in a variety of languages and frameworks.
+description: Generate ready-to-use code snippets for your API requests in JavaScript, Python, Shell, and other languages directly from Hoppscotch.
 ---
 
 Code snippets allows you to rapidly build your API integration in a variety of languages and frameworks.

--- a/documentation/features/spotlight.mdx
+++ b/documentation/features/spotlight.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Spotlight
 title: Spotlight
-description: Powerful search and command palette.
+description: Use the Spotlight search and command palette in Hoppscotch to quickly navigate features, switch tabs, and execute actions with keyboard shortcuts.
 ---
 
 <Tip>Press &nbsp; ⌘ + K &nbsp; anytime to open Spotlight.</Tip>

--- a/documentation/features/variables.mdx
+++ b/documentation/features/variables.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Variables
 title: Variables
-description: Dynamic placeholders for your API interactions.
+description: Use global, environment, request, and collection variables in Hoppscotch to create dynamic, reusable values across your API requests.
 ---
 
 Hoppscotch provides you the ability to create and use variables throughout the app. This helps you reuse values throughout Hoppscotch just by invoking the variable name.

--- a/documentation/features/widgets.mdx
+++ b/documentation/features/widgets.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Widgets
 title: Widgets
-description: Embed Hoppscotch in your website.
+description: Embed Hoppscotch widgets in your website as shareable links, buttons, or interactive embeds so visitors can try your API requests directly.
 ---
 
 Widgets are small, interactive components that can be embedded in HTML pages to provide a seamless experience for your audience. Hoppscotch offers three types of widgets: links, buttons, and embeds.

--- a/documentation/getting-started/clients.mdx
+++ b/documentation/getting-started/clients.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Clients
 title: Hoppscotch Clients
-description: Access Hoppscotch from anywhere.
+description: Explore the Hoppscotch clients available on web, desktop, and CLI. Learn about the user interface and how to navigate the platform.
 ---
 
 import HoppscotchClients from "/snippets/hoppscotch-clients.mdx"

--- a/documentation/getting-started/graphql/creating-a-query.mdx
+++ b/documentation/getting-started/graphql/creating-a-query.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Running a simple query
 title: Running a simple query
-description: Learn how to run a simple query using Hoppscotch.
+description: Connect to a GraphQL server in Hoppscotch, explore the schema documentation, and run your first query step by step with a real API endpoint.
 ---
 
 ## Connecting to a GraphQL server

--- a/documentation/getting-started/graphql/using-variables.mdx
+++ b/documentation/getting-started/graphql/using-variables.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Using variables
 title: Using variables in a GraphQL query
-description: Learn how to use variables in a GraphQL query.
+description: Pass dynamic variables in your GraphQL queries using Hoppscotch. Follow a step-by-step example to filter country data with query variables.
 ---
 
 Hoppscotch allows you to pass variables in the query to fetch data dynamically.

--- a/documentation/getting-started/introduction.mdx
+++ b/documentation/getting-started/introduction.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Introduction
 title: Introduction to Hoppscotch
-description: Open-source API development ecosystem.
+description: Hoppscotch is an open-source API development ecosystem with web, desktop, and CLI clients. A lightweight alternative to Postman and Insomnia.
 ---
 
 Hoppscotch is an open-source API development ecosystem. Available offline, on-prem, and on the cloud with Web, Desktop, and CLI apps — a lightweight, open-source alternative to Postman and Insomnia. Built from the ground up with ease of use and accessibility in mind, providing all the functionality needed for developers with a minimalist, unobtrusive UI.

--- a/documentation/getting-started/quick-start.mdx
+++ b/documentation/getting-started/quick-start.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Quick start
 title: Quick start
-description: Get started with Hoppscotch.
+description: Get started quickly with Hoppscotch Cloud, self-hosted editions, or the desktop app. Choose your platform and begin testing APIs in minutes.
 ---
 
 ## Platforms

--- a/documentation/getting-started/realtime/mqtt.mdx
+++ b/documentation/getting-started/realtime/mqtt.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: MQTT
 title: MQTT
-description: MQTT is a lightweight publish-subscribe messaging protocol.
+description: Connect to an MQTT broker in Hoppscotch to publish messages, subscribe to topics, and test lightweight publish-subscribe messaging.
 ---
 
 ## Connect to an MQTT server

--- a/documentation/getting-started/realtime/socket-io.mdx
+++ b/documentation/getting-started/realtime/socket-io.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Socket.IO
 title: Socket.IO
-description: Learn how to use the Socket.IO testing tool in Hoppscotch.
+description: Test Socket.IO services in Hoppscotch by connecting to a server, listening to events, and sending messages with custom event names.
 ---
 
 The Hoppscotch Socket.io testing tool lets you test out your socket.io services.

--- a/documentation/getting-started/realtime/websocket.mdx
+++ b/documentation/getting-started/realtime/websocket.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Websocket
 title: Websocket
-description: Connect to a WebSocket and send messages.
+description: Connect to a WebSocket server in Hoppscotch, send and receive real-time messages, and troubleshoot common connection issues step by step.
 ---
 
 Enter your WebSocket "**URL**", valid protocols, and click on "**Connect**".

--- a/documentation/getting-started/rest/auth-tokens.mdx
+++ b/documentation/getting-started/rest/auth-tokens.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Using auth tokens
 title: Using auth tokens
-description: Learn how to use authentication tokens in Hoppscotch.
+description: Authenticate API requests in Hoppscotch using bearer tokens. Follow a step-by-step tutorial with the GitHub REST API as an example.
 ---
 
 In this section, we'll look at passing Authorization and Authentication information in our requests, by accessing the [GitHub REST API](https://docs.github.com/en/rest).

--- a/documentation/getting-started/rest/creating-a-request.mdx
+++ b/documentation/getting-started/rest/creating-a-request.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Creating a request
 title: Creating a request
-description: Learn how to create a request in Hoppscotch.
+description: Create your first REST API request in Hoppscotch. Choose an HTTP method, enter an endpoint URL, and send a request to see the response.
 ---
 
 The RESTful protocol is the default protocol that is active when you open Hoppscotch. Hoppscotch allows you to make API requests and examine the responses.

--- a/documentation/getting-started/rest/environment-variables.mdx
+++ b/documentation/getting-started/rest/environment-variables.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Environment variables
 title: Environment variables
-description: Learn how to use environment variables in your requests and scripts.
+description: Store and reuse values like base URLs and API keys with environment variables in Hoppscotch. Create environments and reference variables.
 ---
 
 Environment variables allow you to store and reuse values in your requests and scripts.

--- a/documentation/getting-started/rest/organizing-requests.mdx
+++ b/documentation/getting-started/rest/organizing-requests.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Organizing requests
 title: Organizing requests
-description: Organize your requests categorically for future reference or collaboration with your team using collections.
+description: Save and organize API requests into collections in Hoppscotch for easy reuse, team collaboration, and structured project management.
 ---
 
 It is always a best practice to organize your requests when you test multiple API endpoints. You can organize your requests categorically for future reference or collaboration with your team using collections.

--- a/documentation/getting-started/rest/pre-request-scripts.mdx
+++ b/documentation/getting-started/rest/pre-request-scripts.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Pre-request scripts
 title: Pre-request scripts
-description: Learn how to use pre-request scripts in Hoppscotch.
+description: Add pre-request scripts in Hoppscotch to execute JavaScript before sending API requests. Set variables, generate tokens, and add logic.
 ---
 
 ## Scripts

--- a/documentation/getting-started/rest/request-headers.mdx
+++ b/documentation/getting-started/rest/request-headers.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Request headers
 title: Request headers
-description: Request Headers allow you to pass additional information with requests, helping to control how the server responds.
+description: Set and manage HTTP request headers in Hoppscotch to pass authorization, content type, caching, and other key-value metadata with requests.
 ---
 
 Request Headers are key-value pairs that the client sends to the server with an HTTP request. These headers carry extra details about your request, helping the server understand its context and tailor the response to fit.

--- a/documentation/getting-started/rest/request-parameters.mdx
+++ b/documentation/getting-started/rest/request-parameters.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Request parameters
 title: Request parameters
-description: Request parameters help you to filter and request specific data from an API endpoint.
+description: Add query parameters to API requests in Hoppscotch using the URL or the parameters tab. Filter and request specific data from endpoints.
 ---
 
 Query parameters help you to filter and request specific data from an API endpoint.

--- a/documentation/getting-started/rest/response-handling.mdx
+++ b/documentation/getting-started/rest/response-handling.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Response handling
 title: Response handling
-description: View, interpret and manage responses from your API requests.
+description: Inspect API responses in Hoppscotch including HTTP status codes, JSON/HTML/XML response bodies, headers, cookies, and response time metrics.
 ---
 
 A REST API response is the data returned by the API after an application makes an HTTP request. It typically includes an HTTP status code indicating the result of the request, a response body that contains the requested data, and headers that provide metadata. The response may also include cookies set by the server. 

--- a/documentation/getting-started/rest/tests.mdx
+++ b/documentation/getting-started/rest/tests.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Tests
 title: Tests
-description: Tests are executed after a response is received from the server. You can add multiple tests to a request. You can add tests to both requests saved and not saved in a collection.
+description: Write and run post-request test scripts to validate API responses, check status codes, and verify data. Add tests to saved or unsaved requests.
 ---
 
 ## Scripts

--- a/documentation/getting-started/rest/uploading-data.mdx
+++ b/documentation/getting-started/rest/uploading-data.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Uploading data
 title: Uploading data
-description: Learn how to upload data to an API using Hoppscotch.
+description: Upload files and encoded data to APIs in Hoppscotch using POST or PUT methods with multipart form data, JSON, or binary content types.
 ---
 
 APIs can also be used to upload encoded content to a server. This is usually done with `PUT` or `POST` methods.

--- a/documentation/getting-started/setup.mdx
+++ b/documentation/getting-started/setup.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Setup
 title: Setup Hoppscotch
-description: Learn how to setup Hoppscotch.
+description: Set up Hoppscotch on web, desktop, or the command-line interface. Choose your preferred platform and start building and testing APIs in minutes.
 ---
 
 To get started with Hoppscotch, you need to choose a platform to use it on. Hoppscotch is available on the following platforms:

--- a/documentation/getting-started/troubleshooting.mdx
+++ b/documentation/getting-started/troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Troubleshooting
 title: Troubleshooting
-description: Facing issues with Hoppscotch? Check out this page to resolve them.
+description: Fix common Hoppscotch issues including connectivity problems, CORS errors, browser extensions, and firewall configuration for API testing.
 ---
 
 If you're facing issues with Hoppscotch, you can try the following steps to resolve them.

--- a/documentation/i18n.mdx
+++ b/documentation/i18n.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: i18n
 title: i18n
-description: Internationalization and localization.
+description: Help translate Hoppscotch into your language. Learn how to contribute translations and support internationalization and localization efforts.
 ---
 
 Thanks for showing your interest in helping us to translate the software.

--- a/documentation/protocols/graphql.mdx
+++ b/documentation/protocols/graphql.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: GraphQL
 title: GraphQL
-description: GraphQL is a query language for APIs that queries the server and provides the client only the data that is requested by the client. GraphQL enables you to fetch data from multiple APIs in a single query thus helping you build better-performing applications.
+description: Learn about the GraphQL query language for APIs, how it fetches only requested data, and how to test GraphQL endpoints in Hoppscotch.
 ---
 
 ## Platform

--- a/documentation/protocols/realtime.mdx
+++ b/documentation/protocols/realtime.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Realtime
 title: Realtime
-description: Hoppscotch's Realtime API platform helps you test your real-time APIs easily.
+description: Learn about real-time API protocols supported in Hoppscotch including WebSocket, SSE, Socket.IO, and MQTT for bidirectional communication.
 ---
 
 ## Platform

--- a/documentation/protocols/rest.mdx
+++ b/documentation/protocols/rest.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: RESTful
 title: RESTful
-description: RESTful API testing with Hoppscotch.
+description: Understand the RESTful protocol, HTTP methods like GET, POST, PUT, and DELETE, and how to test REST API endpoints using Hoppscotch.
 ---
 
 ## Platform

--- a/documentation/self-host/community-edition/admin-dashboard.mdx
+++ b/documentation/self-host/community-edition/admin-dashboard.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Admin dashboard
 title: Admin dashboard
-description: Get started with the Hoppscotch Admin Dashboard.
+description: Manage users, invitations, and teams from the Hoppscotch Community Edition admin dashboard. Configure settings and monitor your instance.
 ---
 
 The Admin Dashboard serves as the central hub for managing your workspaces and user-related activities. From here, you can efficiently oversee and control various aspects of your platform.

--- a/documentation/self-host/community-edition/deploy-and-upgrade.mdx
+++ b/documentation/self-host/community-edition/deploy-and-upgrade.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Deploy and upgrade
 title: Deploy and upgrade
-description: Deploy and upgrade Hoppscotch Community Edition on your infrastructure.
+description: Deploy Hoppscotch Community Edition to production and upgrade to newer versions. Includes guides for Docker, subpath access, and migrations.
 ---
 
 This section contains instructions for deploying and upgrading Hoppscotch Community Edition.

--- a/documentation/self-host/community-edition/getting-started.mdx
+++ b/documentation/self-host/community-edition/getting-started.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Getting started
 title: Getting started
-description: Learn how to get started with Hoppscotch Community Edition.
+description: Get started self-hosting Hoppscotch Community Edition. Review the steps for prerequisites, installation, configuration, and deployment.
 ---
 
 Community Edition is the perfect starting point for individual developers or small teams looking to integrate Hoppscotch into their workflow without additional costs. It's open-source, meaning you can modify it as needed, though you'll manage updates and maintenance yourself. With Self Host Community edition you get access to Admin Dashboard which acts as a central hub for managing your workspaces and overseeing user-related activities.

--- a/documentation/self-host/community-edition/install-and-build.mdx
+++ b/documentation/self-host/community-edition/install-and-build.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Install and build
 title: Install and build
-description: Learn how to install and build Hoppscotch Community Edition.
+description: Install and build Hoppscotch Community Edition using Docker. Configure environment variables, authentication providers, and SMTP settings.
 ---
 
 <Tip>If you're interested in deploying <ins>Hoppscotch on Kubernetes</ins>, you can conveniently skip this guide and proceed directly to the [Helm chart deployment guide](/documentation/self-host/helm-chart-deployment/getting-started).</Tip>

--- a/documentation/self-host/community-edition/prerequisites.mdx
+++ b/documentation/self-host/community-edition/prerequisites.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Prerequisites
 title: Prerequisites
-description: Prerequisites for installing Hoppscotch on your own infrastructure.
+description: Review the system requirements, OAuth provider setup, and SMTP configuration needed before installing Hoppscotch Community Edition.
 ---
 
 Hoppscotch is a self-hosted API development platform, packaged as a set of Docker containers. You can install and run Hoppscotch on any operating system that can run a [Docker Engine](https://docs.docker.com/engine). You can use Hoppscotch on your local machine or a cloud provider of your choice.

--- a/documentation/self-host/community-edition/setup-and-access.mdx
+++ b/documentation/self-host/community-edition/setup-and-access.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Setup and access
 title: Setup and access
-description: Learn how to set up and access Hoppscotch Community Edition.
+description: Complete the initial setup of Hoppscotch Community Edition by creating an admin account, configuring access, and verifying your installation.
 ---
 
 After successfully running the necessary containers, the next step involves creating an administrator account to manage Hoppscotch.

--- a/documentation/self-host/community-edition/telemetry.mdx
+++ b/documentation/self-host/community-edition/telemetry.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Telemetry
 title: 'Telemetry'
-description: 'Telemetry and data sharing in Hoppscotch Community Edition'
+description: Understand what telemetry data Hoppscotch Community Edition collects, how it is used, and how to opt out of anonymous usage analytics.
 ---
 
 Telemetry in Hoppscotch Self-Host refers to anonymous data shared with Hoppscotch. This helps identify the usage patterns of Hoppscotch.

--- a/documentation/self-host/enterprise-edition/activity-logs.mdx
+++ b/documentation/self-host/enterprise-edition/activity-logs.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Activity logs
 title: Activity logs
-description: Track all changes made to collections and requests within a workspace, and monitor user interactions through Activity Logs.
+description: Track changes to collections and requests within workspaces using Activity Logs in Hoppscotch Enterprise. Monitor user interactions.
 ---
 
 **Activity Logs** provide a clear record of actions performed within a workspace, including changes to collections, requests, and user interactions. These logs help maintain visibility and traceability of modifications across the workspace.

--- a/documentation/self-host/enterprise-edition/admin-dashboard.mdx
+++ b/documentation/self-host/enterprise-edition/admin-dashboard.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Admin dashboard
 title: Admin dashboard
-description: Get started with the Hoppscotch Admin Dashboard.
+description: Manage users, teams, SCIM provisioning, and license settings from the Hoppscotch Enterprise Edition admin dashboard and its configuration.
 ---
 
 The Admin Dashboard serves as the central hub for managing your workspace and user-related activities. From here, you can efficiently oversee and control various aspects of your platform.

--- a/documentation/self-host/enterprise-edition/deploy-and-upgrade.mdx
+++ b/documentation/self-host/enterprise-edition/deploy-and-upgrade.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Deploy and upgrade
 title: Deploy and upgrade
-description: Deploy and upgrade Hoppscotch Enterprise Edition on your infrastructure.
+description: Deploy Hoppscotch Enterprise Edition to production and upgrade to newer versions. Includes Docker guides, subpath access, and migrations.
 ---
 
 This section contains instructions for deploying and upgrading Hoppscotch Enterprise Edition.

--- a/documentation/self-host/enterprise-edition/getting-started.mdx
+++ b/documentation/self-host/enterprise-edition/getting-started.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Getting started
 title: Getting started
-description: Learn how to get started with Hoppscotch Enterprise Edition.
+description: Get started self-hosting Hoppscotch Enterprise Edition. Review the steps for license activation, prerequisites, installation, and setup.
 ---
 
 Enterprise Edition builds on top of the Community Edition foundation by adding powerful features designed for larger organizations that require robust security measures like SAML-based SSO, OIDC, audit logs, and on-premise deployment options. It also comes with dedicated support to help adapt Hoppscotch to your company's specific needs. The self-hosted enterprise version is open-core in nature, meaning it is accompanied by a set of advanced features that are only available through a commercial license.

--- a/documentation/self-host/enterprise-edition/install-and-build.mdx
+++ b/documentation/self-host/enterprise-edition/install-and-build.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Install and build
 title: Install and build
-description: Learn how to install and build Hoppscotch Enterprise Edition.
+description: Install and build Hoppscotch Enterprise Edition using Docker. Configure environment variables, auth providers, SMTP, and license keys.
 ---
 
 <Tip>If you're interested in deploying <ins>Hoppscotch on Kubernetes</ins>, you can conveniently skip this guide and proceed directly to the [Helm chart deployment guide](/documentation/self-host/helm-chart-deployment/getting-started).</Tip>

--- a/documentation/self-host/enterprise-edition/observability.mdx
+++ b/documentation/self-host/enterprise-edition/observability.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Observability
 title: Observability
-description: Monitor and improve your Hoppscotch instance with OpenTelemetry integration.
+description: Set up OpenTelemetry observability for Hoppscotch Enterprise to monitor traces, metrics, and logs. Integrate with Grafana, Jaeger, and more.
 ---
 
 Observability support helps you understand what's happening inside your self-hosted Hoppscotch instance. With OpenTelemetry integration, you can track performance, diagnose issues faster, and gain insights into how your APIs are being used.

--- a/documentation/self-host/enterprise-edition/prerequisites.mdx
+++ b/documentation/self-host/enterprise-edition/prerequisites.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Prerequisites
 title: Prerequisites
-description: Prerequisites for installing Hoppscotch on your own infrastructure.
+description: Review system requirements, OAuth provider setup, SMTP, and license key configuration needed before installing Hoppscotch Enterprise.
 ---
 
 Hoppscotch is a self-hosted API development platform, packaged as a set of Docker containers. You can install and run Hoppscotch on any operating system that can run a [Docker Engine](https://docs.docker.com/engine). You can use Hoppscotch on your local machine or a cloud provider of your choice.

--- a/documentation/self-host/enterprise-edition/setup-and-access.mdx
+++ b/documentation/self-host/enterprise-edition/setup-and-access.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Setup and access
 title: Setup and access
-description: Learn how to set up and access Hoppscotch Enterprise Edition.
+description: Complete the initial setup of Hoppscotch Enterprise Edition by creating an admin account, activating your license, and configuring access.
 ---
 
 After successfully running the necessary containers, the next step involves creating an administrator account to manage Hoppscotch.

--- a/documentation/self-host/enterprise-edition/telemetry.mdx
+++ b/documentation/self-host/enterprise-edition/telemetry.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Telemetry
 title: 'Telemetry'
-description: 'Telemetry and data sharing in Hoppscotch Enterprise Edition'
+description: Understand what telemetry data Hoppscotch Enterprise Edition collects, how it is used, and how to manage anonymous usage analytics.
 ---
 
 Telemetry in Hoppscotch Self-Host refers to anonymous data shared with Hoppscotch. This helps identify the usage patterns of Hoppscotch.

--- a/documentation/self-host/enterprise-edition/user-groups.mdx
+++ b/documentation/self-host/enterprise-edition/user-groups.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: User groups
 title: User groups
-description: User groups allow admins to manage user permissions and roles in a shared workspace, providing a structured way to control access and actions within the workspace.
+description: Create and manage user groups to control permissions and roles in shared workspaces. Assign members to groups for structured access control.
 ---
 
 User groups are a powerful feature that enables admins to manage user permissions and roles within a shared workspace. This structured approach allows for efficient control over access and actions, ensuring that users can only perform tasks relevant to their roles.

--- a/documentation/self-host/enterprise-edition/user-provisioning.mdx
+++ b/documentation/self-host/enterprise-edition/user-provisioning.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: User provisioning
 title: SCIM Integration for User Provisioning
-description: Manage users efficiently with SCIM provisioning in Hoppscotch.
+description: Set up SCIM integration in Hoppscotch Enterprise to automate user provisioning, deprovisioning, and group sync with identity providers.
 ---
 
 User management can become overwhelming as your organization scales. **SCIM (System for Cross-domain Identity Management)** offers a standardized way to handle user provisioning, updates, and deprovisioning. With SCIM integration, Hoppscotch connects directly to your Identity Provider (IdP), helping you manage users in one place and reflect those changes across systems.

--- a/documentation/self-host/getting-started.mdx
+++ b/documentation/self-host/getting-started.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Getting started
 title: Getting started
-description: Welcome to Hoppscotch Self-Host.
+description: Self-host Hoppscotch on your own infrastructure with full data ownership. Choose between Community Edition and Enterprise Edition.
 ---
 
 This section will help you get started with self-hosting your instance of Hoppscotch. If you are looking to self-host your instance of [Hoppscotch](https://github.com/hoppscotch/hoppscotch) you will need to have to install a few other dependencies. Go through our prerequisite guide below to install all the required dependencies and have the required information ready.

--- a/documentation/self-host/helm-chart-deployment/digital-ocean.mdx
+++ b/documentation/self-host/helm-chart-deployment/digital-ocean.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Digital Ocean
 title: Digital Ocean
-description: Install and configure Hoppscotch on Digital Ocean using Helm Charts for cloud-based deployment.
+description: Deploy Hoppscotch on DigitalOcean Kubernetes using Helm charts. Follow a step-by-step guide for cluster setup, configuration, and ingress.
 ---
 
 [DigitalOcean](https://www.digitalocean.com/) is a cloud provider that offers scalable and easy-to-use infrastructure for developers. You can create and manage Kubernetes clusters, storage, and networking resources all through their platform.

--- a/documentation/self-host/helm-chart-deployment/getting-started.mdx
+++ b/documentation/self-host/helm-chart-deployment/getting-started.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Helm Chart Deployment
 title: Getting Started
-description: Deploy Hoppscotch on your Kubernetes cluster using Helm charts.
+description: Get started deploying Hoppscotch on Kubernetes using Helm charts. Review supported platforms and choose a deployment target for your cluster.
 ---
 
 Deploying Hoppscotch [Community](/documentation/self-host/community-edition/getting-started) and [Enterprise](/documentation/self-host/enterprise-edition/getting-started) editions with Helm charts makes it easier to manage your self-hosted instance on [Kubernetes](https://kubernetes.io/). 

--- a/guides/articles.mdx
+++ b/guides/articles.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Index
 title: Index
-description: Complete list of articles and guides for Hoppscotch.
+description: Browse all Hoppscotch guides and tutorials covering API testing, self-hosting, GraphQL, OpenTelemetry, enterprise features, and more.
 ---
 
 <Tip>Interested in writing an article about Hoppscotch? Contact us at `support@hoppscotch.io`.</Tip>

--- a/guides/articles/audit-logs.mdx
+++ b/guides/articles/audit-logs.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Audit Logs in Hoppscotch
 title: Audit Logs in Hoppscotch
-description: Learn about the audit logs in Hoppscotch Enterprise.
+description: Enable and use audit logs in Hoppscotch Enterprise to track workspace activity, collection changes, and user actions for compliance.
 ---
 
 In Enterprise Hoppscotch, a record of all actions taken on the platform is saved which can be used to know what events happened, who performed them, and when they occurred. With the information present users may be able to draw insights related to the platform.

--- a/guides/articles/downgrading-and-restoring-backups.mdx
+++ b/guides/articles/downgrading-and-restoring-backups.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Downgrading and Restoring Backups
 title: Downgrading and Restoring Backups
-description: If an update causes issues with Hoppscotch Desktop, you can downgrade to a previous version and restore your data from an automatic backup. This guide will walk you through the entire process safely.
+description: Downgrade the Hoppscotch Desktop App to a previous version and safely restore your data from automatic backups when an update causes issues.
 ---
 
 If an update causes issues with Hoppscotch Desktop, you can downgrade to a previous version and restore your data from an automatic backup. This guide will walk you through the entire process safely.

--- a/guides/articles/improving-your-api-workflow.mdx
+++ b/guides/articles/improving-your-api-workflow.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: API Workflow
 title: Improving your API workflow
-description: Learn how to improve your API workflow with Hoppscotch.
+description: Streamline your API development workflow with Hoppscotch using collections, environments, scripts, and team collaboration features.
 ---
 
 Hoppscotch provides you with a minimal and blazing platform to design, develop and test your APIs. Hoppscotch enables you to quickly get started and even helps you to organize your work to help you improve your workflow.

--- a/guides/articles/manage-an-enterprise-license-key.mdx
+++ b/guides/articles/manage-an-enterprise-license-key.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Enterprise License Key
 title: Managing your Enterprise License Key
-description: Learn how to manage your Hoppscotch Enterprise Edition license key.
+description: Activate, renew, and manage your Hoppscotch Enterprise Edition license key. Troubleshoot license issues and understand key expiration.
 ---
 
 This guide provides step-by-step instructions for managing your Hoppscotch Enterprise Edition license key. If you plan to self-host the Hoppscotch Enterprise Edition, you must obtain a License Key.

--- a/guides/articles/restful-api-testing-with-hoppscotch.mdx
+++ b/guides/articles/restful-api-testing-with-hoppscotch.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: RESTful API Testing
 title: RESTful API testing with Hoppscotch
-description: Learn how to use Hoppscotch to test your RESTful APIs.
+description: Follow a hands-on tutorial to test RESTful APIs with Hoppscotch. Send GET and POST requests, add headers, and inspect JSON responses.
 ---
 
 Representational State Transfer (REST) APIs are a core part of communication between a web/mobile client and a server. The majority of web-based applications depend on REST APIs to fetch and modify data thus separating the data processing part from the front-end. Hoppscotch provides a fast and intuitive platform to develop and test REST APIs making it easier for developers worldwide to work efficiently.

--- a/guides/articles/self-host-hoppscotch-on-your-own-servers.mdx
+++ b/guides/articles/self-host-hoppscotch-on-your-own-servers.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Self-Host Hoppscotch
 title: Self-Host Hoppscotch on your own servers
-description: Set up Hoppscotch on your servers for complete control and customization.
+description: Self-host Hoppscotch on your own servers with Docker. Configure OAuth providers, SMTP, environment variables, and deploy step by step.
 ---
 
 Self-hosting Hoppscotch gives you complete control over your API development workflow and allows you to deploy Hoppscotch in your own data center or cloud, giving you greater control over data and security.

--- a/guides/articles/set-up-opentelemetry-stack-with-docker.mdx
+++ b/guides/articles/set-up-opentelemetry-stack-with-docker.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: OpenTelemetry Integration
 title: Set Up OpenTelemetry Stack with Docker
-description: A guide to setting up the OpenTelemetry stack using Docker.
+description: Set up the OpenTelemetry observability stack with Docker for Hoppscotch Enterprise. Configure collectors, Jaeger, Grafana, and Prometheus.
 ---
 
 This guide will help you set up the **OpenTelemetry Collector** on your own server and connect it with **Hoppscotch**.

--- a/guides/articles/understanding-graphql.mdx
+++ b/guides/articles/understanding-graphql.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: GraphQL API Testing
 title: Understanding the GraphQL Schema on Hoppscotch
-description: Learn how to use the GraphQL schema on Hoppscotch.
+description: Explore the GraphQL schema in Hoppscotch to understand queries, mutations, types, and subscriptions. Inspect and navigate API documentation.
 ---
 
 The GraphQL schema is at the core of any GraphQL server. It defines the capabilities of the API and specifies how clients can access that data. A schema includes types and fields, queries and mutations, interfaces, and unions. Hoppscotch provides you the functionality to connect to a GraphQL server and explore the GraphQL schema.

--- a/guides/articles/uplifting-web-experience-with-hoppscotch-widgets.mdx
+++ b/guides/articles/uplifting-web-experience-with-hoppscotch-widgets.mdx
@@ -1,9 +1,7 @@
 ---
 sidebarTitle: Hoppscotch Widgets
 title: Uplifting web experience with Hoppscotch Widgets
-description:
-  Create and add interactive and dynamic elements to your website using
-  Hoppscotch Widgets.
+description: Embed interactive Hoppscotch widgets in your website as links, buttons, or iframes so visitors can run API requests directly from your pages.
 ---
 
 Widgets are interactive components that can be embedded in HTML pages to enhance

--- a/guides/getting-started/introduction.mdx
+++ b/guides/getting-started/introduction.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Introduction
 title: Introduction
-description: Guides and tutorials to help you get started with Hoppscotch.
+description: Browse step-by-step Hoppscotch guides and tutorials on API testing, self-hosting, GraphQL, integrations, and enterprise administration.
 ---
 
 Hoppscotch is a free and open-source API development platform to help you build, test, and document APIs faster. It is a web-based API development environment that allows you to send requests and view responses in a single interface.

--- a/index.mdx
+++ b/index.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Home
 title: Hoppscotch Documentation
-description: Find user guides, quickstarts, tutorials, use cases, code samples, and more.
+description: Official Hoppscotch documentation with guides, quickstarts, API references, and tutorials for the open-source API development platform.
 ---
 
 import { PrimaryButton } from '/snippets/components.mdx';

--- a/support/code-of-conduct.mdx
+++ b/support/code-of-conduct.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Code of conduct
 title: Code of conduct
-description: Code of conduct for Hoppscotch.
+description: Read the Hoppscotch community code of conduct. Guidelines for respectful participation, reporting violations, and enforcement policies.
 ---
 
 ## Our Pledge

--- a/support/getting-started/contact.mdx
+++ b/support/getting-started/contact.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Contact
 title: Contact
-description: Contact us to get technical support, report a bug, suggest a new feature or improvement, or join our community.
+description: Contact the Hoppscotch team for technical support, bug reports, feature requests, or to connect with the community on Discord and GitHub.
 ---
 
 ## Technical support

--- a/support/getting-started/faq.mdx
+++ b/support/getting-started/faq.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: FAQ
 title: Frequently Asked Questions
-description: These are the most frequently asked questions about Hoppscotch.
+description: Find answers to common questions about Hoppscotch including pricing, self-hosting, data privacy, integrations, and platform features.
 ---
 
 Find answers to the most frequently asked questions about Hoppscotch.

--- a/support/getting-started/introduction.mdx
+++ b/support/getting-started/introduction.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Introduction
 title: Introduction
-description: We're here to help you get started with Hoppscotch.
+description: Get help with Hoppscotch through documentation, FAQs, community forums, and direct support channels. Find the right resource for your needs.
 ---
 
 Discover the different support offers to answer your questions, help you get started, and provide you with the best experience possible.

--- a/support/license.mdx
+++ b/support/license.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: License
 title: License
-description: Hoppscotch is licensed under MIT License.
+description: Review the MIT License under which Hoppscotch is distributed. Understand the permissions, conditions, and limitations of the license.
 ---
 
 ```

--- a/support/privacy.mdx
+++ b/support/privacy.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Privacy policy
 title: Privacy policy
-description: Privacy policy for Hoppscotch.
+description: Read the Hoppscotch privacy policy to understand how your personal data is collected, used, stored, and protected when using our services.
 ---
 
 This Privacy Policy describes how Hoppscotch Limited. (“**Hoppscotch**,” “**we**,” “**us**,” or “**our**”) processes personal information that we collect through our digital or online properties or services that link to this Privacy Policy (including as applicable, our website, mobile application, social media pages, marketing activities, and other activities described in this Privacy Policy (collectively, the “**Service**”)).

--- a/support/security-policy.mdx
+++ b/support/security-policy.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Security policy
 title: Security policy
-description: Security procedures and general policies for Hoppscotch.
+description: Review the Hoppscotch security policy including vulnerability reporting procedures, responsible disclosure guidelines, and security practices.
 ---
 
 This document outlines security procedures and general policies for the Hoppscotch project.

--- a/support/solutions/community.mdx
+++ b/support/solutions/community.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Community
 title: Community
-description: Hoppscotch is an open-source project. Community is at the heart of everything we do.
+description: Get help from the Hoppscotch open-source community on Discord and GitHub. Ask questions, share ideas, and connect with other developers.
 ---
 
 ## GitHub Issues

--- a/support/solutions/experts.mdx
+++ b/support/solutions/experts.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Experts
 title: Hoppscotch Experts
-description: Get help from our experts.
+description: Get dedicated help from Hoppscotch experts for enterprise support, custom integrations, onboarding, and advanced API workflow consulting.
 ---
 
 Our expert network is a group of experienced engineers with expertise in Hoppscotch, carefully selected by the Hoppscotch team. They are available to help you with your questions and issues.

--- a/support/terms.mdx
+++ b/support/terms.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: Terms and conditions
 title: Terms and conditions
-description: Terms and conditions for Hoppscotch.
+description: Read the Hoppscotch terms and conditions covering acceptable use, intellectual property, liability, and service agreement for all users.
 ---
 
 Hoppscotch Limited is committed to ensuring that the app is as useful and efficient as possible. For that reason, we reserve the right to make changes to the app or to charge for its services at any time and for any reason. We will not charge you for the app or its services without making it clear to you exactly what you're paying for.


### PR DESCRIPTION

[motivation.txt](https://github.com/user-attachments/files/32399325/motivation.txt)
Audit and update frontmatter descriptions on 100 MDX files to meet SEO best practices: target 130-160 characters, unique per page, and include relevant search terms. Fix 4 overly long descriptions, resolve 2 duplicate description pairs, and expand 96 short descriptions.

Generated-By: mintlify-agent